### PR TITLE
feat(ui): MLS parity — full frontend for Sprints 1–7 backend

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -34,6 +34,13 @@ const AdminChats = lazy(() => import('./pages/AdminChats'));
 const AdminUsers = lazy(() => import('./pages/AdminUsers'));
 const SellerCalculator = lazy(() => import('./pages/SellerCalculator'));
 const Yad2Import = lazy(() => import('./pages/Yad2Import'));
+// MLS parity — Sprint 1/4/5 new pages. Lazy so each lands in its own
+// chunk and the Dashboard-first-paint budget doesn't regress.
+const Reports = lazy(() => import('./pages/Reports'));
+const ActivityLog = lazy(() => import('./pages/ActivityLog'));
+const Reminders = lazy(() => import('./pages/Reminders'));
+const Office = lazy(() => import('./pages/Office'));
+const TagSettings = lazy(() => import('./pages/TagSettings'));
 const CommandPalette = lazy(() => import('./components/CommandPalette'));
 import { AuthProvider, useAuth } from './lib/auth';
 import ShortcutsOverlay from './components/ShortcutsOverlay';
@@ -179,6 +186,12 @@ function AppRoutes() {
             <Route path="/admin/users" element={<AdminUsers />} />
             <Route path="/calculator" element={<SellerCalculator />} />
             <Route path="/integrations/yad2" element={<Yad2Import />} />
+            {/* MLS parity — Sprint 4/5/1 standalone pages. */}
+            <Route path="/reports" element={<Reports />} />
+            <Route path="/activity" element={<ActivityLog />} />
+            <Route path="/reminders" element={<Reminders />} />
+            <Route path="/office" element={<Office />} />
+            <Route path="/settings/tags" element={<TagSettings />} />
             {/* Legacy + alias routes — redirect.
                 `/assets` is a reasonable English guess for "נכסים"
                 (literally "assets") — hitting the 404 felt like a bug

--- a/frontend/src/components/ActivityPanel.css
+++ b/frontend/src/components/ActivityPanel.css
@@ -1,0 +1,75 @@
+/* ActivityPanel — scoped styles. Matches the card framing used by
+   RemindersPanel and MatchingList so all three embed consistently. */
+
+.activity-panel {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md, 10px);
+  padding: 16px;
+}
+
+.ap-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.ap-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--gold);
+}
+
+.ap-loading,
+.ap-error {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-muted);
+  font-size: 13px;
+  padding: 12px 4px;
+}
+.ap-error { color: var(--danger, #b00020); }
+
+.ap-list { list-style: none; margin: 0; padding: 0; position: relative; }
+.ap-list::before {
+  content: '';
+  position: absolute;
+  top: 10px;
+  bottom: 10px;
+  inset-inline-end: 7px;
+  width: 1px;
+  background: var(--border);
+}
+
+.ap-item {
+  display: flex;
+  gap: 12px;
+  padding: 8px 0;
+  position: relative;
+}
+
+.ap-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--gold);
+  margin-top: 6px;
+  flex-shrink: 0;
+  margin-inline-start: 3px;
+  position: relative;
+  z-index: 1;
+  box-shadow: 0 0 0 3px var(--bg-card);
+}
+
+.ap-body { flex: 1; min-width: 0; }
+.ap-line { font-size: 13px; color: var(--text-primary); }
+.ap-actor { font-weight: 600; margin-inline-end: 4px; }
+.ap-action { color: var(--text-secondary); }
+.ap-time { display: block; font-size: 11px; color: var(--text-muted); margin-top: 2px; }

--- a/frontend/src/components/ActivityPanel.jsx
+++ b/frontend/src/components/ActivityPanel.jsx
@@ -1,0 +1,89 @@
+import { useCallback, useEffect, useState } from 'react';
+import { History, Loader2, AlertCircle } from 'lucide-react';
+import api from '../lib/api';
+import EmptyState from './EmptyState';
+import { relativeTime, absoluteTime } from '../lib/time';
+import './ActivityPanel.css';
+
+// ──────────────────────────────────────────────────────────────────
+// ActivityPanel — read-only activity-log list for any entity.
+//
+// Backend returns entries shaped like:
+//   { id, kind, action, actorName?, createdAt, summary? }
+// The list sorts newest-first server-side; we just render. When both
+// entityType + entityId are passed, the feed is scoped to that entity.
+// ──────────────────────────────────────────────────────────────────
+export default function ActivityPanel({
+  entityType,
+  entityId,
+  limit = 20,
+  title = 'יומן פעילות',
+}) {
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const load = useCallback(async () => {
+    if (!entityType || !entityId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await api.listActivity({ entityType, entityId, limit });
+      setItems(res?.items || []);
+    } catch (e) {
+      setError(e?.message || 'טעינת הפעילות נכשלה');
+    } finally {
+      setLoading(false);
+    }
+  }, [entityType, entityId, limit]);
+
+  useEffect(() => { load(); }, [load]);
+
+  return (
+    <section className="activity-panel" aria-label={title} dir="rtl">
+      <header className="ap-header">
+        <h3 className="ap-title">
+          <History size={16} aria-hidden />
+          {title}
+        </h3>
+      </header>
+
+      {loading ? (
+        <div className="ap-loading" role="status">
+          <Loader2 size={16} className="y2-spin" aria-hidden />
+          <span>טוען…</span>
+        </div>
+      ) : error ? (
+        <div className="ap-error" role="alert">
+          <AlertCircle size={14} aria-hidden />
+          <span>{error}</span>
+        </div>
+      ) : items.length === 0 ? (
+        <EmptyState
+          variant="filtered"
+          title="אין פעילות עדיין"
+          description="עדכונים אוטומטיים יופיעו כאן ככל שהלקוח מתקדם."
+        />
+      ) : (
+        <ul className="ap-list">
+          {items.map((ev) => (
+            <li key={ev.id} className="ap-item">
+              <div className="ap-dot" aria-hidden />
+              <div className="ap-body">
+                <div className="ap-line">
+                  {ev.actorName && <span className="ap-actor">{ev.actorName}</span>}
+                  <span className="ap-action">{ev.summary || ev.action || ev.kind}</span>
+                </div>
+                {ev.createdAt && (
+                  <time className="ap-time" dateTime={ev.createdAt} title={absoluteTime(ev.createdAt)}>
+                    {relativeTime(ev.createdAt)}
+                  </time>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/ActivityPanel.jsx
+++ b/frontend/src/components/ActivityPanel.jsx
@@ -1,0 +1,16 @@
+// Minimal stub — will be superseded by Agent B's implementation at
+// integration time.
+//
+// Props (must match Agent B's contract):
+//   scope: { leadId?: string, propertyId?: string, customerId?: string }
+
+export default function ActivityPanel({ scope }) {
+  return (
+    <div
+      className="activity-panel-stub"
+      data-scope={JSON.stringify(scope || {})}
+    >
+      <h3>פעילות</h3>
+    </div>
+  );
+}

--- a/frontend/src/components/AddressField.css
+++ b/frontend/src/components/AddressField.css
@@ -164,3 +164,18 @@
     max-height: min(280px, calc(var(--vh-usable, 60vh) - 16px));
   }
 }
+
+/* MLS G1 — optional neighborhood sub-field. Stacks under the street
+   row with a small gap and shares the list / item styles above. */
+.addr-field-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+}
+
+.addr-field-nbh.addr-field-disabled .addr-field-input {
+  background: var(--surface-2, #f3f4f6);
+  cursor: not-allowed;
+}
+

--- a/frontend/src/components/AddressField.jsx
+++ b/frontend/src/components/AddressField.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { MapPin, Search as SearchIcon, Check, X } from 'lucide-react';
 import api from '../lib/api';
+import { useNeighborhoodSuggestions } from '../hooks/useNeighborhoodSuggestions';
 import './AddressField.css';
 
 /**
@@ -37,6 +38,14 @@ export default function AddressField({
   autoFocus = false,
   id,
   'aria-label': ariaLabel,
+  // MLS G1 — optional secondary field for neighborhoods. Pass
+  // `showNeighborhood` + controlled `neighborhood` / `onNeighborhoodChange`
+  // to opt into the new subfield. Existing callers leave these blank
+  // and see no change.
+  showNeighborhood = false,
+  neighborhood = '',
+  onNeighborhoodChange,
+  neighborhoodPlaceholder = 'שכונה (רשות)',
 }) {
   const [local, setLocal] = useState(value ?? '');
   const [results, setResults] = useState([]);
@@ -187,7 +196,7 @@ export default function AddressField({
     inputRef.current?.focus();
   };
 
-  return (
+  const streetBox = (
     <div className={`addr-field ${invalid ? 'addr-invalid' : ''} ${picked ? 'addr-picked' : ''}`}>
       <span className="addr-field-icon" aria-hidden="true">
         {picked ? <Check size={14} /> : <MapPin size={14} />}
@@ -289,6 +298,128 @@ export default function AddressField({
               </li>
             );
           })}
+        </ul>
+      )}
+    </div>
+  );
+
+  if (!showNeighborhood) return streetBox;
+  return (
+    <div className="addr-field-wrap">
+      {streetBox}
+      <NeighborhoodSubField
+        city={city}
+        value={neighborhood}
+        onChange={onNeighborhoodChange}
+        placeholder={neighborhoodPlaceholder}
+      />
+    </div>
+  );
+}
+
+// MLS G1 — optional secondary input sitting below the street row. When
+// a city is set, typing here suggests matches from the Neighborhood
+// table; picking one or leaving free text both propagate through
+// onNeighborhoodChange. Disabled (with a visual hint) when no city is
+// known yet, so the agent understands they need to pick a place first.
+function NeighborhoodSubField({ city, value = '', onChange, placeholder }) {
+  const [query, setQuery] = useState(value || '');
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  // Keep the local input in sync when the parent swaps the value
+  // externally (e.g. loading an existing record into an edit form).
+  const [lastExternal, setLastExternal] = useState(value || '');
+  if ((value || '') !== lastExternal) {
+    setLastExternal(value || '');
+    setQuery(value || '');
+  }
+  const disabled = !((city || '').trim());
+  const { items, loading, error } = useNeighborhoodSuggestions(city, query);
+
+  const pick = (name) => {
+    setQuery(name);
+    setOpen(false);
+    setActiveIndex(-1);
+    onChange?.(name);
+  };
+
+  const onKeyDown = (e) => {
+    if (!open) return;
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActiveIndex((i) => Math.min(items.length - 1, i + 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIndex((i) => Math.max(0, i - 1));
+    } else if (e.key === 'Enter') {
+      if (activeIndex >= 0 && items[activeIndex]) {
+        e.preventDefault();
+        pick(items[activeIndex].name);
+      }
+    } else if (e.key === 'Escape') {
+      setOpen(false);
+      setActiveIndex(-1);
+    }
+  };
+
+  return (
+    <div className={`addr-field addr-field-nbh ${disabled ? 'addr-field-disabled' : ''}`}>
+      <span className="addr-field-icon" aria-hidden="true">
+        <MapPin size={14} />
+      </span>
+      <input
+        type="text"
+        className="addr-field-input form-input"
+        value={query}
+        disabled={disabled}
+        placeholder={disabled ? 'בחר עיר תחילה' : placeholder}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setOpen(true);
+          // Free text flows through immediately; the parent persists
+          // whatever the agent has typed whether or not they pick a
+          // suggestion row.
+          onChange?.(e.target.value);
+        }}
+        onFocus={() => { if (items.length) setOpen(true); }}
+        onBlur={() => setTimeout(() => setOpen(false), 150)}
+        onKeyDown={onKeyDown}
+        aria-label="שכונה"
+        aria-autocomplete="list"
+        aria-expanded={open}
+        aria-controls="addr-field-nbh-list"
+        autoComplete="off"
+        autoCorrect="off"
+        spellCheck={false}
+      />
+      {loading && <span className="addr-field-loader" aria-hidden="true" />}
+      {open && !disabled && (items.length > 0 || error) && (
+        <ul id="addr-field-nbh-list" className="addr-field-list" role="listbox">
+          {error && (
+            <li className="addr-field-err">
+              <SearchIcon size={12} /> {error}
+            </li>
+          )}
+          {items.map((item, i) => (
+            <li
+              key={item.id || `${item.name}-${i}`}
+              role="option"
+              aria-selected={i === activeIndex}
+              className={`addr-field-item ${i === activeIndex ? 'is-active' : ''}`}
+              onMouseDown={(e) => { e.preventDefault(); pick(item.name); }}
+              onMouseEnter={() => setActiveIndex(i)}
+            >
+              <span className="addr-field-item-icon" aria-hidden="true">
+                <MapPin size={12} />
+              </span>
+              <span className="addr-field-item-text">
+                <strong>{item.name}</strong>
+                {item.aliases?.length > 0 && (
+                  <small>{item.aliases.slice(0, 2).join(' · ')}</small>
+                )}
+              </span>
+            </li>
+          ))}
         </ul>
       )}
     </div>

--- a/frontend/src/components/AdvertsPanel.css
+++ b/frontend/src/components/AdvertsPanel.css
@@ -1,0 +1,118 @@
+/* AdvertsPanel — per-channel marketing adverts for a property. */
+
+.adp-root {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.adp-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.adp-title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.adp-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px;
+  border-radius: 12px;
+  background: var(--bg-subtle, #f7f7f8);
+  border: 1px solid var(--border-subtle, #e2e2e6);
+}
+
+.adp-form-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 10px;
+}
+
+.adp-form-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.adp-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.adp-item {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px;
+  border-radius: 12px;
+  background: var(--bg-default, #fff);
+  border: 1px solid var(--border-subtle, #e2e2e6);
+}
+
+.adp-item-published {
+  border-color: #b7e4a7;
+  background: #f7fdf4;
+}
+
+.adp-item-paused,
+.adp-item-expired {
+  background: #fff9ef;
+  border-color: #f0dda0;
+}
+
+.adp-item-removed {
+  opacity: 0.55;
+}
+
+.adp-item-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.adp-item-channel {
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.adp-item-link {
+  display: inline-flex;
+  align-items: center;
+  text-decoration: none;
+  color: var(--text-muted, #555);
+}
+
+.adp-item-remove {
+  margin-inline-start: auto;
+}
+
+.adp-item-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 12px;
+  color: var(--text-muted, #555);
+}
+
+.adp-item-title {
+  color: var(--text-default, #222);
+  font-weight: 500;
+}
+
+.adp-hint {
+  color: var(--text-muted, #757575);
+  font-size: 13px;
+  margin: 4px 0;
+}

--- a/frontend/src/components/AdvertsPanel.jsx
+++ b/frontend/src/components/AdvertsPanel.jsx
@@ -1,0 +1,301 @@
+import { useEffect, useState, useId } from 'react';
+import { Plus, Trash2, ExternalLink } from 'lucide-react';
+import api from '../lib/api';
+import { NumberField, SelectField } from './SmartFields';
+import EmptyState from './EmptyState';
+import { displayDate, displayPrice } from '../lib/display';
+import {
+  ADVERT_CHANNEL_LABELS,
+  ADVERT_STATUS_LABELS,
+  labelsToOptions,
+  labelFor,
+} from '../lib/mlsLabels';
+import './AdvertsPanel.css';
+
+// F1 — per-channel marketing adverts.
+//
+// Displays the per-property list of adverts (one row per channel/status
+// combination), plus an expandable "new advert" form. Each row lets the
+// agent transition status (draft → published → paused/expired) via a
+// status <select> that PATCHes in place, and a remove button.
+//
+// Fields written to the server on create/update:
+//   channel | status | title | body | publishedPrice |
+//   externalUrl | externalId | publishedAt | expiresAt
+
+const CHANNEL_OPTIONS = labelsToOptions(ADVERT_CHANNEL_LABELS);
+const STATUS_OPTIONS = labelsToOptions(ADVERT_STATUS_LABELS);
+
+const emptyDraft = () => ({
+  channel: 'YAD2',
+  status: 'DRAFT',
+  title: '',
+  body: '',
+  publishedPrice: null,
+  externalUrl: '',
+  externalId: '',
+});
+
+export default function AdvertsPanel({ propertyId, toast }) {
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [creating, setCreating] = useState(false);
+  const [draft, setDraft] = useState(emptyDraft);
+  const [saving, setSaving] = useState(false);
+  const [busyId, setBusyId] = useState(null);
+  const titleId = useId();
+
+  const load = async () => {
+    if (!propertyId) return;
+    setLoading(true);
+    try {
+      const res = await api.listAdverts(propertyId);
+      setItems(res?.items || []);
+    } catch (e) {
+      toast?.error?.(e?.message || 'טעינת המודעות נכשלה');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { load(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [propertyId]);
+
+  const submitCreate = async (e) => {
+    e?.preventDefault?.();
+    setSaving(true);
+    try {
+      const body = {
+        channel: draft.channel,
+        status: draft.status || 'DRAFT',
+        title: draft.title || null,
+        body: draft.body || null,
+        publishedPrice: draft.publishedPrice == null || draft.publishedPrice === ''
+          ? null
+          : Number(draft.publishedPrice),
+        externalUrl: draft.externalUrl || null,
+        externalId: draft.externalId || null,
+      };
+      await api.createAdvert(propertyId, body);
+      toast?.success?.(`המודעה ב${labelFor(ADVERT_CHANNEL_LABELS, draft.channel)} נוצרה`);
+      setDraft(emptyDraft());
+      setCreating(false);
+      await load();
+    } catch (e2) {
+      toast?.error?.(e2?.message || 'יצירת המודעה נכשלה');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const changeStatus = async (advert, nextStatus) => {
+    if (!advert?.id || nextStatus === advert.status) return;
+    setBusyId(advert.id);
+    try {
+      const body = { status: nextStatus };
+      // When moving to PUBLISHED, stamp publishedAt if not already set.
+      if (nextStatus === 'PUBLISHED' && !advert.publishedAt) {
+        body.publishedAt = new Date().toISOString();
+      }
+      await api.updateAdvert(advert.id, body);
+      toast?.success?.(`סטטוס עודכן ל${labelFor(ADVERT_STATUS_LABELS, nextStatus)}`);
+      await load();
+    } catch (e) {
+      toast?.error?.(e?.message || 'עדכון הסטטוס נכשל');
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const remove = async (advertId) => {
+    setBusyId(advertId);
+    try {
+      await api.deleteAdvert(advertId);
+      toast?.info?.('המודעה הוסרה');
+      await load();
+    } catch (e) {
+      toast?.error?.(e?.message || 'הסרה נכשלה');
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const d = (k, v) => setDraft((p) => ({ ...p, [k]: v }));
+
+  return (
+    <section className="adp-root" aria-labelledby={titleId}>
+      <header className="adp-head">
+        <h3 id={titleId} className="adp-title">מודעות פרסום</h3>
+        {!creating && (
+          <button
+            type="button"
+            className="btn btn-secondary btn-sm"
+            onClick={() => setCreating(true)}
+          >
+            <Plus size={14} aria-hidden="true" />
+            מודעה חדשה
+          </button>
+        )}
+      </header>
+
+      {creating && (
+        <form className="adp-form" onSubmit={submitCreate} aria-label="טופס מודעה חדשה">
+          <div className="adp-form-row">
+            <div className="form-group">
+              <label className="form-label" htmlFor="adp-channel">ערוץ</label>
+              <SelectField
+                id="adp-channel"
+                value={draft.channel}
+                onChange={(v) => d('channel', v)}
+                options={CHANNEL_OPTIONS}
+                aria-label="ערוץ המודעה"
+              />
+            </div>
+            <div className="form-group">
+              <label className="form-label" htmlFor="adp-status-new">סטטוס ראשוני</label>
+              <SelectField
+                id="adp-status-new"
+                value={draft.status}
+                onChange={(v) => d('status', v)}
+                options={STATUS_OPTIONS}
+                aria-label="סטטוס ראשוני"
+              />
+            </div>
+            <div className="form-group">
+              <label className="form-label" htmlFor="adp-price">מחיר מפורסם</label>
+              <NumberField
+                id="adp-price"
+                value={draft.publishedPrice}
+                onChange={(v) => d('publishedPrice', v)}
+                unit="₪"
+                placeholder="2,500,000"
+                showShort
+                aria-label="מחיר מפורסם"
+              />
+            </div>
+          </div>
+          <div className="form-group">
+            <label className="form-label" htmlFor="adp-title">כותרת</label>
+            <input
+              id="adp-title"
+              type="text"
+              className="form-input"
+              value={draft.title}
+              onChange={(e) => d('title', e.target.value)}
+              placeholder="4 חד׳ משופצת ברח׳ הרצל"
+            />
+          </div>
+          <div className="form-group">
+            <label className="form-label" htmlFor="adp-body">תיאור</label>
+            <textarea
+              id="adp-body"
+              className="form-textarea"
+              rows={3}
+              dir="auto"
+              value={draft.body}
+              onChange={(e) => d('body', e.target.value)}
+              placeholder="תיאור קצר למודעה…"
+            />
+          </div>
+          <div className="adp-form-row">
+            <div className="form-group">
+              <label className="form-label" htmlFor="adp-url">קישור חיצוני</label>
+              <input
+                id="adp-url"
+                type="url"
+                className="form-input"
+                dir="ltr"
+                value={draft.externalUrl}
+                onChange={(e) => d('externalUrl', e.target.value)}
+                placeholder="https://…"
+              />
+            </div>
+            <div className="form-group">
+              <label className="form-label" htmlFor="adp-extid">מזהה חיצוני</label>
+              <input
+                id="adp-extid"
+                type="text"
+                className="form-input"
+                dir="ltr"
+                value={draft.externalId}
+                onChange={(e) => d('externalId', e.target.value)}
+                placeholder="YAD2-12345"
+              />
+            </div>
+          </div>
+          <div className="adp-form-actions">
+            <button type="submit" className="btn btn-primary" disabled={saving}>
+              {saving ? 'שומר…' : 'שמור מודעה'}
+            </button>
+            <button
+              type="button"
+              className="btn btn-ghost"
+              onClick={() => { setCreating(false); setDraft(emptyDraft()); }}
+            >
+              ביטול
+            </button>
+          </div>
+        </form>
+      )}
+
+      {loading ? (
+        <p className="adp-hint">טוען…</p>
+      ) : items.length === 0 && !creating ? (
+        <EmptyState
+          title="אין עדיין מודעות"
+          description="צור מודעה לכל ערוץ פרסום כדי לעקוב אחרי הסטטוסים במקום אחד"
+          action={{ label: 'מודעה חדשה', onClick: () => setCreating(true) }}
+          variant="first"
+        />
+      ) : items.length > 0 && (
+        <ul className="adp-list">
+          {items.map((a) => (
+            <li key={a.id} className={`adp-item adp-item-${String(a.status).toLowerCase()}`}>
+              <div className="adp-item-head">
+                <span className="adp-item-channel">
+                  {labelFor(ADVERT_CHANNEL_LABELS, a.channel)}
+                </span>
+                <SelectField
+                  value={a.status}
+                  onChange={(v) => changeStatus(a, v)}
+                  options={STATUS_OPTIONS}
+                  aria-label={`שנה סטטוס למודעה ב${labelFor(ADVERT_CHANNEL_LABELS, a.channel)}`}
+                  disabled={busyId === a.id}
+                />
+                {a.externalUrl && (
+                  <a
+                    href={a.externalUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="adp-item-link"
+                    aria-label="פתח מודעה בערוץ החיצוני"
+                  >
+                    <ExternalLink size={14} aria-hidden="true" />
+                  </a>
+                )}
+                <button
+                  type="button"
+                  className="btn btn-ghost btn-sm adp-item-remove"
+                  onClick={() => remove(a.id)}
+                  disabled={busyId === a.id}
+                  aria-label={`הסר את המודעה ב${labelFor(ADVERT_CHANNEL_LABELS, a.channel)}`}
+                >
+                  <Trash2 size={14} aria-hidden="true" />
+                </button>
+              </div>
+              <div className="adp-item-meta">
+                {a.title && <strong className="adp-item-title">{a.title}</strong>}
+                <span className="adp-item-price">{displayPrice(a.publishedPrice)}</span>
+                {a.publishedAt && (
+                  <span className="adp-item-when">פורסם: {displayDate(a.publishedAt)}</span>
+                )}
+                {a.expiresAt && (
+                  <span className="adp-item-when">תוקף: {displayDate(a.expiresAt)}</span>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/AdvertsPanel.jsx
+++ b/frontend/src/components/AdvertsPanel.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useId } from 'react';
+import { useCallback, useEffect, useState, useId } from 'react';
 import { Plus, Trash2, ExternalLink } from 'lucide-react';
 import api from '../lib/api';
 import { NumberField, SelectField } from './SmartFields';
@@ -45,7 +45,7 @@ export default function AdvertsPanel({ propertyId, toast }) {
   const [busyId, setBusyId] = useState(null);
   const titleId = useId();
 
-  const load = async () => {
+  const load = useCallback(async () => {
     if (!propertyId) return;
     setLoading(true);
     try {
@@ -56,9 +56,9 @@ export default function AdvertsPanel({ propertyId, toast }) {
     } finally {
       setLoading(false);
     }
-  };
+  }, [propertyId, toast]);
 
-  useEffect(() => { load(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [propertyId]);
+  useEffect(() => { load(); }, [load]);
 
   const submitCreate = async (e) => {
     e?.preventDefault?.();

--- a/frontend/src/components/CommandPalette.jsx
+++ b/frontend/src/components/CommandPalette.jsx
@@ -1,10 +1,23 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Search, Building2, Users, Handshake, LayoutDashboard, Plus, UserPlus, User } from 'lucide-react';
+import {
+  Search,
+  Building2,
+  Users,
+  Handshake,
+  LayoutDashboard,
+  Plus,
+  UserPlus,
+  User,
+  UserCircle,
+} from 'lucide-react';
 import api from '../lib/api';
 import Portal from './Portal';
+import { useDebouncedValue } from '../lib/useDebouncedValue';
 import './CommandPalette.css';
 
+// Static list — always visible at the top of the palette, even offline.
+// Dynamic server-backed entries (H1 globalSearch) are appended below.
 const STATIC_ENTRIES = [
   { kind: 'nav', icon: LayoutDashboard, title: 'לוח בקרה',   to: '/' },
   { kind: 'nav', icon: Building2,        title: 'נכסים',      to: '/properties' },
@@ -15,56 +28,137 @@ const STATIC_ENTRIES = [
   { kind: 'action', icon: UserPlus,      title: 'ליד חדש',      to: '/customers/new' },
 ];
 
+// Format helpers for the server result shapes. The backend (H1) returns
+// partial objects; be tolerant about which field is populated.
+function propertyLabel(p) {
+  const street = [p.street, p.number].filter(Boolean).join(' ').trim();
+  const parts = [street || p.address || '', p.city || ''].filter(Boolean);
+  return parts.join(', ') || 'נכס';
+}
+
+function propertySub(p) {
+  return [p.type, p.owner, p.neighborhood].filter(Boolean).join(' · ') || '';
+}
+
+function leadSub(l) {
+  return [l.city, l.phone].filter(Boolean).join(' · ');
+}
+
+function ownerSub(o) {
+  return [o.email, o.phone].filter(Boolean).join(' · ');
+}
+
+function dealLabel(d) {
+  return d.title || d.propertyAddress || d.propertyTitle || `עסקה #${d.id}`;
+}
+
+function dealSub(d) {
+  return [d.status, d.stage, d.propertyAddress].filter(Boolean).join(' · ');
+}
+
 export default function CommandPalette({ open, onClose }) {
   const navigate = useNavigate();
   const [q, setQ] = useState('');
-  const [props, setProps] = useState([]);
-  const [leads, setLeads] = useState([]);
+  const [results, setResults] = useState({ properties: [], leads: [], owners: [], deals: [] });
+  const [loading, setLoading] = useState(false);
   const [index, setIndex] = useState(0);
   const inputRef = useRef(null);
 
-  // Load searchable data once when the palette first opens
+  // 250ms debounce — feels instant to an agent typing Hebrew, batches
+  // per-key requests so a three-letter query hits the server once.
+  const debouncedQ = useDebouncedValue(q.trim(), 250);
+
+  // Reset when the palette opens. We don't prefetch anything; the server
+  // global-search endpoint handles an empty string (no results).
   useEffect(() => {
     if (!open) return;
     setQ('');
     setIndex(0);
+    setResults({ properties: [], leads: [], owners: [], deals: [] });
     setTimeout(() => inputRef.current?.focus(), 50);
-    (async () => {
-      try {
-        const [p, l] = await Promise.all([
-          api.listProperties({ mine: '1' }).catch(() => ({ items: [] })),
-          api.listLeads().catch(() => ({ items: [] })),
-        ]);
-        setProps(p.items || []);
-        setLeads(l.items || []);
-      } catch { /* ignore */ }
-    })();
   }, [open]);
 
-  const query = q.trim().toLowerCase();
-  const propMatches = !query ? [] : props.filter((p) =>
-    p.street?.toLowerCase().includes(query) ||
-    p.city?.toLowerCase().includes(query) ||
-    p.owner?.toLowerCase().includes(query) ||
-    p.type?.toLowerCase().includes(query)
-  ).slice(0, 6);
-  const leadMatches = !query ? [] : leads.filter((l) =>
-    l.name?.toLowerCase().includes(query) ||
-    l.phone?.includes(query) ||
-    l.city?.toLowerCase().includes(query)
-  ).slice(0, 6);
-  const navMatches = STATIC_ENTRIES.filter((e) =>
-    !query || e.title.includes(q.trim())
-  );
+  // Hit api.globalSearch whenever the debounced query changes while open.
+  // AbortController cancels in-flight requests if the user keeps typing —
+  // important on slow networks so stale results never overwrite newer.
+  useEffect(() => {
+    if (!open) return undefined;
+    if (!debouncedQ) {
+      setResults({ properties: [], leads: [], owners: [], deals: [] });
+      setLoading(false);
+      return undefined;
+    }
+    let cancelled = false;
+    setLoading(true);
+    api.globalSearch(debouncedQ).then(
+      (data) => {
+        if (cancelled) return;
+        setResults({
+          properties: data?.properties || [],
+          leads:      data?.leads      || [],
+          owners:     data?.owners     || [],
+          deals:      data?.deals      || [],
+        });
+        setIndex(0);
+        setLoading(false);
+      },
+      () => {
+        if (cancelled) return;
+        // Swallow errors silently — the palette should degrade to just
+        // static nav entries rather than crash. The error toast surface
+        // is wrong for a passive dropdown like this.
+        setResults({ properties: [], leads: [], owners: [], deals: [] });
+        setLoading(false);
+      },
+    );
+    return () => { cancelled = true; };
+  }, [debouncedQ, open]);
 
-  const flat = [
-    ...navMatches.map((e) => ({ ...e, kind: e.kind })),
-    ...leadMatches.map((l) => ({ kind: 'lead', icon: Users, title: l.name, subtitle: `${l.city || ''} · ${l.phone || ''}`, to: `/customers?selected=${l.id}` })),
-    ...propMatches.map((p) => ({ kind: 'property', icon: Building2, title: `${p.street}, ${p.city}`, subtitle: `${p.type} · ${p.owner}`, to: `/properties/${p.id}` })),
-  ];
+  // Build the flat, ordered item list. Navigation order = render order
+  // so keyboard arrow navigation matches the visible sections top-down.
+  const { navMatches, flat } = useMemo(() => {
+    const query = q.trim();
+    const nav = STATIC_ENTRIES.filter((e) => !query || e.title.includes(query));
+    const propItems = results.properties.map((p) => ({
+      kind: 'property',
+      icon: Building2,
+      id: p.id,
+      title: propertyLabel(p),
+      subtitle: propertySub(p),
+      to: `/properties/${p.id}`,
+    }));
+    const leadItems = results.leads.map((l) => ({
+      kind: 'lead',
+      icon: Users,
+      id: l.id,
+      title: l.name || 'ליד',
+      subtitle: leadSub(l),
+      to: `/customers?selected=${l.id}`,
+    }));
+    const ownerItems = results.owners.map((o) => ({
+      kind: 'owner',
+      icon: UserCircle,
+      id: o.id,
+      title: o.name || 'בעל נכס',
+      subtitle: ownerSub(o),
+      to: `/owners/${o.id}`,
+    }));
+    const dealItems = results.deals.map((d) => ({
+      kind: 'deal',
+      icon: Handshake,
+      id: d.id,
+      title: dealLabel(d),
+      subtitle: dealSub(d),
+      to: '/deals',
+    }));
+    return {
+      navMatches: nav,
+      flat: [...nav, ...propItems, ...leadItems, ...ownerItems, ...dealItems],
+    };
+  }, [q, results]);
 
   useEffect(() => {
-    if (!open) return;
+    if (!open) return undefined;
     function onKey(e) {
       if (e.key === 'Escape') { e.preventDefault(); onClose(); return; }
       if (e.key === 'ArrowDown') { e.preventDefault(); setIndex((i) => Math.min(flat.length - 1, i + 1)); }
@@ -80,10 +174,25 @@ export default function CommandPalette({ open, onClose }) {
 
   if (!open) return null;
 
+  const hasQuery = debouncedQ.length > 0;
+  const totalDynamic = results.properties.length + results.leads.length + results.owners.length + results.deals.length;
+  // Group offsets so each Item knows its flat-list index for highlight.
+  const navCount   = navMatches.length;
+  const propOffset = navCount;
+  const leadOffset = propOffset + results.properties.length;
+  const ownerOffset = leadOffset + results.leads.length;
+  const dealOffset  = ownerOffset + results.owners.length;
+
   return (
     <Portal>
       <div className="cmdp-backdrop" onClick={onClose}>
-        <div className="cmdp-modal" onClick={(e) => e.stopPropagation()}>
+        <div
+          className="cmdp-modal"
+          role="dialog"
+          aria-modal="true"
+          aria-label="חיפוש"
+          onClick={(e) => e.stopPropagation()}
+        >
           <div className="cmdp-search">
             <Search size={16} />
             <input
@@ -94,7 +203,7 @@ export default function CommandPalette({ open, onClose }) {
               autoCorrect="off"
               autoCapitalize="off"
               spellCheck={false}
-              placeholder="חפש לקוח, נכס או מסך… (⌘K)"
+              placeholder="חפש לקוח, נכס, בעלים, עסקה… (⌘K)"
               value={q}
               onChange={(e) => { setQ(e.target.value); setIndex(0); }}
             />
@@ -104,35 +213,64 @@ export default function CommandPalette({ open, onClose }) {
             {navMatches.length > 0 && (
               <Section title="ניווט">
                 {navMatches.map((e, i) => (
-                  <Item key={e.to} item={e} active={index === i} onPick={() => { navigate(e.to); onClose(); }} />
-                ))}
-              </Section>
-            )}
-            {leadMatches.length > 0 && (
-              <Section title="לקוחות">
-                {leadMatches.map((l, i) => (
                   <Item
-                    key={l.id}
-                    item={{ icon: Users, title: l.name, subtitle: `${l.city || ''} · ${l.phone || ''}` }}
-                    active={index === navMatches.length + i}
-                    onPick={() => { navigate(`/customers?selected=${l.id}`); onClose(); }}
+                    key={e.to}
+                    item={e}
+                    active={index === i}
+                    onPick={() => { navigate(e.to); onClose(); }}
                   />
                 ))}
               </Section>
             )}
-            {propMatches.length > 0 && (
+            {results.properties.length > 0 && (
               <Section title="נכסים">
-                {propMatches.map((p, i) => (
+                {results.properties.map((p, i) => (
                   <Item
-                    key={p.id}
-                    item={{ icon: Building2, title: `${p.street}, ${p.city}`, subtitle: `${p.type} · ${p.owner}` }}
-                    active={index === navMatches.length + leadMatches.length + i}
+                    key={`p-${p.id}`}
+                    item={{ icon: Building2, title: propertyLabel(p), subtitle: propertySub(p) }}
+                    active={index === propOffset + i}
                     onPick={() => { navigate(`/properties/${p.id}`); onClose(); }}
                   />
                 ))}
               </Section>
             )}
-            {query && leadMatches.length === 0 && propMatches.length === 0 && navMatches.length === 0 && (
+            {results.leads.length > 0 && (
+              <Section title="לקוחות">
+                {results.leads.map((l, i) => (
+                  <Item
+                    key={`l-${l.id}`}
+                    item={{ icon: Users, title: l.name || 'ליד', subtitle: leadSub(l) }}
+                    active={index === leadOffset + i}
+                    onPick={() => { navigate(`/customers?selected=${l.id}`); onClose(); }}
+                  />
+                ))}
+              </Section>
+            )}
+            {results.owners.length > 0 && (
+              <Section title="בעלים">
+                {results.owners.map((o, i) => (
+                  <Item
+                    key={`o-${o.id}`}
+                    item={{ icon: UserCircle, title: o.name || 'בעל נכס', subtitle: ownerSub(o) }}
+                    active={index === ownerOffset + i}
+                    onPick={() => { navigate(`/owners/${o.id}`); onClose(); }}
+                  />
+                ))}
+              </Section>
+            )}
+            {results.deals.length > 0 && (
+              <Section title="עסקאות">
+                {results.deals.map((d, i) => (
+                  <Item
+                    key={`d-${d.id}`}
+                    item={{ icon: Handshake, title: dealLabel(d), subtitle: dealSub(d) }}
+                    active={index === dealOffset + i}
+                    onPick={() => { navigate('/deals'); onClose(); }}
+                  />
+                ))}
+              </Section>
+            )}
+            {hasQuery && !loading && totalDynamic === 0 && navMatches.length === 0 && (
               <div className="cmdp-empty">לא נמצאו תוצאות</div>
             )}
           </div>

--- a/frontend/src/components/CustomerFiltersPanel.css
+++ b/frontend/src/components/CustomerFiltersPanel.css
@@ -189,6 +189,27 @@
   flex: 1;
 }
 
+/* MLS G1 — location section (cities + neighborhoods picker). */
+.cfp-location-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.cfp-location-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--text-muted, #6b7280);
+}
+
+@media (max-width: 600px) {
+  .cfp-location-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 /* Mobile: full-screen drawer feels better than a right pane on
  * narrow viewports. */
 @media (max-width: 600px) {

--- a/frontend/src/components/CustomerFiltersPanel.css
+++ b/frontend/src/components/CustomerFiltersPanel.css
@@ -1,0 +1,198 @@
+/* Sprint 2 / MLS parity — C2. Right-side drawer for the Customers
+ * filter panel. Backdrop darkens the page, panel slides in from the
+ * start edge (RTL: right side) and occupies a fixed width on desktop,
+ * full width on mobile. */
+
+.cfp-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 90;
+  display: flex;
+  justify-content: flex-start;
+  animation: cfp-fade-in 160ms ease;
+}
+
+@keyframes cfp-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.cfp-panel {
+  width: min(420px, 100vw);
+  max-width: 100vw;
+  height: 100vh;
+  background: var(--surface, #fff);
+  color: inherit;
+  box-shadow: -12px 0 24px rgba(0, 0, 0, 0.14);
+  display: flex;
+  flex-direction: column;
+  animation: cfp-slide-in 220ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+@keyframes cfp-slide-in {
+  from { transform: translateX(12%); opacity: 0.85; }
+  to   { transform: translateX(0);   opacity: 1; }
+}
+
+.cfp-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border, rgba(0, 0, 0, 0.08));
+}
+
+.cfp-head-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.cfp-head-title h3 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.cfp-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  height: 22px;
+  padding: 0 6px;
+  border-radius: 999px;
+  background: var(--gold, #d4a017);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.cfp-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+
+.cfp-close:hover {
+  background: var(--surface-hover, rgba(0, 0, 0, 0.05));
+}
+
+.cfp-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.cfp-section h4 {
+  margin: 0 0 8px 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-muted, #55555d);
+}
+
+.cfp-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.cfp-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 12px;
+  border: 1px solid var(--border, rgba(0, 0, 0, 0.14));
+  border-radius: 999px;
+  background: var(--surface-muted, #fafafa);
+  color: inherit;
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 1.25;
+  transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease;
+}
+
+.cfp-chip:hover {
+  background: var(--surface-hover, rgba(0, 0, 0, 0.04));
+}
+
+.cfp-chip.sel {
+  background: var(--gold-soft, rgba(212, 160, 23, 0.15));
+  border-color: var(--gold, #d4a017);
+  color: var(--gold-strong, #b8890f);
+  font-weight: 600;
+}
+
+.cfp-chip:focus-visible {
+  outline: 2px solid var(--focus-ring, #7a6cff);
+  outline-offset: 1px;
+}
+
+.cfp-tag {
+  border-left: 3px solid var(--tag-color, var(--border, rgba(0, 0, 0, 0.14)));
+  padding-inline-start: 10px;
+}
+
+.cfp-range-pair {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.cfp-range-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--text-muted, #55555d);
+}
+
+.cfp-range-cap {
+  font-weight: 600;
+}
+
+.cfp-mini-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.cfp-mini-grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--text-muted, #55555d);
+}
+
+.cfp-foot {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 12px 16px;
+  border-top: 1px solid var(--border, rgba(0, 0, 0, 0.08));
+  background: var(--surface, #fff);
+}
+
+.cfp-foot .btn-primary,
+.cfp-foot .btn-ghost {
+  flex: 1;
+}
+
+/* Mobile: full-screen drawer feels better than a right pane on
+ * narrow viewports. */
+@media (max-width: 600px) {
+  .cfp-panel {
+    width: 100vw;
+  }
+}

--- a/frontend/src/components/CustomerFiltersPanel.jsx
+++ b/frontend/src/components/CustomerFiltersPanel.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { X, SlidersHorizontal } from 'lucide-react';
 import { NumberField } from './SmartFields';
+import NeighborhoodPicker from './NeighborhoodPicker';
 import Portal from './Portal';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 import {
@@ -221,6 +222,50 @@ export default function CustomerFiltersPanel({
               />
             </section>
 
+            {/* Location — cities (free-text comma-separated) + neighborhoods.
+                The neighborhood picker is keyed off the first city in the
+                list so the seed table can scope suggestions. When no city
+                is picked the picker is disabled with a prompt. */}
+            <section className="cfp-section">
+              <h4>מיקום</h4>
+              <div className="cfp-location-grid">
+                <label className="cfp-location-cell">
+                  <span>ערים</span>
+                  <CitiesInput
+                    value={draft.cities || []}
+                    onChange={(arr) => {
+                      setDraft((prev) => {
+                        const copy = { ...prev };
+                        if (arr.length) copy.cities = arr;
+                        else delete copy.cities;
+                        // When the first city changes, drop stale
+                        // neighborhoods that belonged to the previous one.
+                        if ((prev.cities?.[0] || '') !== (arr[0] || '')) {
+                          delete copy.neighborhoods;
+                        }
+                        return copy;
+                      });
+                    }}
+                  />
+                </label>
+                <label className="cfp-location-cell">
+                  <span>שכונות</span>
+                  <NeighborhoodPicker
+                    city={draft.cities?.[0] || ''}
+                    value={draft.neighborhoods || []}
+                    onChange={(arr) => {
+                      setDraft((prev) => {
+                        const copy = { ...prev };
+                        if (arr.length) copy.neighborhoods = arr;
+                        else delete copy.neighborhoods;
+                        return copy;
+                      });
+                    }}
+                  />
+                </label>
+              </div>
+            </section>
+
             {/* Budget range */}
             <section className="cfp-section">
               <h4>תקציב</h4>
@@ -348,5 +393,30 @@ export default function CustomerFiltersPanel({
         </aside>
       </div>
     </Portal>
+  );
+}
+
+// Minimal CSV city input — agents usually filter by a single city so the
+// dedicated chip picker would be overkill. Users type names separated by
+// commas; on blur we normalize to trimmed entries. Matches the existing
+// CsvInput pattern used elsewhere in the app.
+function CitiesInput({ value, onChange }) {
+  const [text, setText] = useState((value || []).join(', '));
+  useEffect(() => { setText((value || []).join(', ')); }, [value]);
+  const commit = () => {
+    const arr = text.split(',').map((s) => s.trim()).filter(Boolean);
+    onChange(arr);
+  };
+  return (
+    <input
+      className="form-input"
+      dir="auto"
+      placeholder="תל אביב, רמת גן"
+      aria-label="ערים"
+      value={text}
+      onChange={(e) => setText(e.target.value)}
+      onBlur={commit}
+      onKeyDown={(e) => { if (e.key === 'Enter') commit(); }}
+    />
   );
 }

--- a/frontend/src/components/CustomerFiltersPanel.jsx
+++ b/frontend/src/components/CustomerFiltersPanel.jsx
@@ -1,0 +1,352 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { X, SlidersHorizontal } from 'lucide-react';
+import { NumberField } from './SmartFields';
+import Portal from './Portal';
+import { useFocusTrap } from '../hooks/useFocusTrap';
+import {
+  LEAD_HEAT_LABELS,
+  CUSTOMER_STATUS_LABELS,
+  QUICK_LEAD_STATUS_LABELS,
+  SERIOUSNESS_LABELS,
+  PROPERTY_TYPE_LABELS,
+  labelOptions,
+} from '../lib/mlsLabels';
+import api from '../lib/api';
+import './CustomerFiltersPanel.css';
+
+// Sprint 2 / MLS parity — Task C2. Nadlan-parity filter drawer for the
+// Customers page. Opens from the "סנן" button, shows every filter the
+// backend accepts (listed in spec / routes/leads.ts), and yields a
+// filters object via `onApply(filters)` when the agent submits.
+//
+// Shape of the yielded object mirrors the backend's query params so the
+// caller can pass it straight to api.listLeads. Empty arrays / null
+// values are stripped so we don't serialize `?cities=` or `?heat=`.
+//
+// Modal a11y: role="dialog", aria-modal="true", useFocusTrap. Escape
+// closes, backdrop click closes, "החל סינון" commits + closes.
+//
+// Props:
+//   open      boolean
+//   filters   current filter object (used as initial state each open)
+//   onApply(filters)  commit handler — parent re-fetches /leads with it
+//   onClose() close handler
+export default function CustomerFiltersPanel({
+  open,
+  filters = {},
+  onApply,
+  onClose,
+}) {
+  // Keep a local editable copy of the filters so toggling chips doesn't
+  // refetch the whole list on every click — we only commit on "החל סינון".
+  const [draft, setDraft] = useState(filters);
+  const [tags, setTags] = useState([]);
+  const panelRef = useRef(null);
+
+  // Re-seed draft when the drawer (re)opens so a stale edit doesn't
+  // carry between sessions.
+  useEffect(() => {
+    if (open) setDraft(filters);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  // Fetch the agent's tag library once the drawer opens.
+  useEffect(() => {
+    if (!open) return undefined;
+    let cancelled = false;
+    api.listTags()
+      .then((r) => { if (!cancelled) setTags(r?.items || []); })
+      .catch(() => { /* soft-fail: the tag group renders empty */ });
+    return () => { cancelled = true; };
+  }, [open]);
+
+  useFocusTrap(panelRef, { onEscape: onClose });
+
+  // Helpers to toggle array entries / flip booleans on the draft.
+  const toggleInArray = (key, value) => {
+    setDraft((prev) => {
+      const arr = Array.isArray(prev[key]) ? prev[key] : [];
+      const has = arr.includes(value);
+      const next = has ? arr.filter((x) => x !== value) : [...arr, value];
+      const copy = { ...prev };
+      if (next.length) copy[key] = next;
+      else delete copy[key];
+      return copy;
+    });
+  };
+
+  const toggleBool = (key) => {
+    setDraft((prev) => {
+      const copy = { ...prev };
+      if (copy[key]) delete copy[key];
+      else copy[key] = true;
+      return copy;
+    });
+  };
+
+  const setNumber = (key, n) => {
+    setDraft((prev) => {
+      const copy = { ...prev };
+      if (n == null || n === '' || !Number.isFinite(Number(n))) delete copy[key];
+      else copy[key] = Number(n);
+      return copy;
+    });
+  };
+
+  const clearAll = () => setDraft({});
+
+  const apply = () => {
+    onApply?.(draft);
+    onClose?.();
+  };
+
+  // Active count for the header summary. Each key contributes 1; the
+  // actual UI intentionally doesn't dissect arrays into sub-pills because
+  // "Filters" surfaces only top-level groups.
+  const activeCount = useMemo(() => (
+    Object.entries(draft).filter(([, v]) => {
+      if (Array.isArray(v)) return v.length > 0;
+      return v !== null && v !== undefined && v !== '' && v !== false;
+    }).length
+  ), [draft]);
+
+  if (!open) return null;
+
+  // Reusable group of on/off chips. value is a string; selected => aria-pressed.
+  const ChipGroup = ({ group, values }) => (
+    <div className="cfp-chips" role="group">
+      {values.map(({ value, label }) => {
+        const selected = (draft[group] || []).includes(value);
+        return (
+          <button
+            key={value}
+            type="button"
+            className={`cfp-chip ${selected ? 'sel' : ''}`}
+            aria-pressed={selected}
+            onClick={() => toggleInArray(group, value)}
+          >
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+
+  const BoolChip = ({ k, label }) => {
+    const selected = !!draft[k];
+    return (
+      <button
+        type="button"
+        className={`cfp-chip ${selected ? 'sel' : ''}`}
+        aria-pressed={selected}
+        onClick={() => toggleBool(k)}
+      >
+        {label}
+      </button>
+    );
+  };
+
+  return (
+    <Portal>
+      <div className="cfp-backdrop" onClick={onClose}>
+        <aside
+          className="cfp-panel"
+          role="dialog"
+          aria-modal="true"
+          aria-label="סינון מתקדם"
+          ref={panelRef}
+          onClick={(e) => e.stopPropagation()}
+          dir="rtl"
+        >
+          <header className="cfp-head">
+            <div className="cfp-head-title">
+              <SlidersHorizontal size={18} aria-hidden="true" />
+              <h3>סינון מתקדם</h3>
+              {activeCount > 0 && (
+                <span className="cfp-count" aria-label={`${activeCount} סינונים פעילים`}>
+                  {activeCount}
+                </span>
+              )}
+            </div>
+            <button
+              type="button"
+              className="btn-ghost cfp-close"
+              onClick={onClose}
+              aria-label="סגור"
+            >
+              <X size={18} aria-hidden="true" />
+            </button>
+          </header>
+
+          <div className="cfp-body">
+            {/* Lead heat (HOT/WARM/COLD) */}
+            <section className="cfp-section">
+              <h4>חום ליד</h4>
+              <ChipGroup group="heat" values={labelOptions(LEAD_HEAT_LABELS)} />
+            </section>
+
+            {/* Quick lead status (Nadlan LeadStatusID) */}
+            <section className="cfp-section">
+              <h4>סטטוס ליד</h4>
+              <ChipGroup
+                group="leadStatus"
+                values={labelOptions(QUICK_LEAD_STATUS_LABELS)}
+              />
+            </section>
+
+            {/* Customer lifecycle */}
+            <section className="cfp-section">
+              <h4>סטטוס לקוח</h4>
+              <ChipGroup
+                group="customerStatus"
+                values={labelOptions(CUSTOMER_STATUS_LABELS)}
+              />
+            </section>
+
+            {/* Seriousness */}
+            <section className="cfp-section">
+              <h4>רצינות</h4>
+              <ChipGroup
+                group="seriousness"
+                values={labelOptions(SERIOUSNESS_LABELS)}
+              />
+            </section>
+
+            {/* Property types */}
+            <section className="cfp-section">
+              <h4>סוגי נכס</h4>
+              <ChipGroup
+                group="types"
+                values={labelOptions(PROPERTY_TYPE_LABELS)}
+              />
+            </section>
+
+            {/* Budget range */}
+            <section className="cfp-section">
+              <h4>תקציב</h4>
+              <div className="cfp-range-pair">
+                <label className="cfp-range-cell">
+                  <span className="cfp-range-cap">מ</span>
+                  <NumberField
+                    aria-label="תקציב מינימום"
+                    value={draft.minPrice ?? null}
+                    onChange={(n) => setNumber('minPrice', n)}
+                    unit="₪"
+                    placeholder="0"
+                  />
+                </label>
+                <label className="cfp-range-cell">
+                  <span className="cfp-range-cap">עד</span>
+                  <NumberField
+                    aria-label="תקציב מקסימום"
+                    value={draft.maxPrice ?? null}
+                    onChange={(n) => setNumber('maxPrice', n)}
+                    unit="₪"
+                    placeholder="ללא הגבלה"
+                  />
+                </label>
+              </div>
+            </section>
+
+            {/* Rooms + floor ranges */}
+            <section className="cfp-section">
+              <h4>חדרים וקומות</h4>
+              <div className="cfp-mini-grid">
+                <label>
+                  <span>מינ׳ חדרים</span>
+                  <NumberField
+                    aria-label="מינימום חדרים"
+                    value={draft.minRoom ?? null}
+                    onChange={(n) => setNumber('minRoom', n)}
+                    placeholder="0"
+                  />
+                </label>
+                <label>
+                  <span>מקס׳ חדרים</span>
+                  <NumberField
+                    aria-label="מקסימום חדרים"
+                    value={draft.maxRoom ?? null}
+                    onChange={(n) => setNumber('maxRoom', n)}
+                    placeholder="ללא"
+                  />
+                </label>
+                <label>
+                  <span>מינ׳ קומה</span>
+                  <NumberField
+                    aria-label="מינימום קומה"
+                    value={draft.minFloor ?? null}
+                    onChange={(n) => setNumber('minFloor', n)}
+                    placeholder="0"
+                  />
+                </label>
+                <label>
+                  <span>מקס׳ קומה</span>
+                  <NumberField
+                    aria-label="מקסימום קומה"
+                    value={draft.maxFloor ?? null}
+                    onChange={(n) => setNumber('maxFloor', n)}
+                    placeholder="ללא"
+                  />
+                </label>
+              </div>
+            </section>
+
+            {/* Boolean requirements */}
+            <section className="cfp-section">
+              <h4>דרישות חובה</h4>
+              <div className="cfp-chips">
+                <BoolChip k="parkingRequired"  label="חניה" />
+                <BoolChip k="balconyRequired"  label="מרפסת" />
+                <BoolChip k="elevatorRequired" label="מעלית" />
+                <BoolChip k="safeRoomRequired" label="ממ״ד" />
+                <BoolChip k="acRequired"       label="מיזוג" />
+                <BoolChip k="storageRequired"  label="מחסן" />
+              </div>
+            </section>
+
+            {/* Tag library (A2). Empty until the agent creates tags. */}
+            {tags.length > 0 && (
+              <section className="cfp-section">
+                <h4>תגיות</h4>
+                <div className="cfp-chips">
+                  {tags.map((t) => {
+                    const selected = (draft.tags || []).includes(t.id);
+                    return (
+                      <button
+                        key={t.id}
+                        type="button"
+                        className={`cfp-chip cfp-tag ${selected ? 'sel' : ''}`}
+                        aria-pressed={selected}
+                        onClick={() => toggleInArray('tags', t.id)}
+                        style={t.color ? { ['--tag-color']: t.color } : undefined}
+                      >
+                        {t.name}
+                      </button>
+                    );
+                  })}
+                </div>
+              </section>
+            )}
+          </div>
+
+          <footer className="cfp-foot">
+            <button
+              type="button"
+              className="btn btn-ghost"
+              onClick={clearAll}
+            >
+              נקה הכל
+            </button>
+            <button
+              type="button"
+              className="btn btn-primary"
+              onClick={apply}
+            >
+              החל סינון
+            </button>
+          </footer>
+        </aside>
+      </div>
+    </Portal>
+  );
+}

--- a/frontend/src/components/DateRangePicker.css
+++ b/frontend/src/components/DateRangePicker.css
@@ -1,0 +1,69 @@
+/* E2 — DateRangePicker: two native date inputs plus quick-range chips. */
+
+.drp-root {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.drp-fields {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.drp-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 160px;
+  flex: 1;
+}
+
+.drp-label {
+  font-size: 12px;
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+
+.drp-input {
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg-card);
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: 14px;
+}
+
+.drp-input:focus {
+  outline: 2px solid var(--gold, #c9a14a);
+  outline-offset: 1px;
+}
+
+.drp-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.drp-chip {
+  padding: 6px 12px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-elevated, transparent);
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.drp-chip:hover {
+  background: var(--bg-card);
+  border-color: var(--gold, #c9a14a);
+}
+
+.drp-chip-clear {
+  color: var(--text-secondary);
+}

--- a/frontend/src/components/DateRangePicker.jsx
+++ b/frontend/src/components/DateRangePicker.jsx
@@ -1,0 +1,100 @@
+import './DateRangePicker.css';
+
+// E2 — Reusable date-range picker (controlled component).
+//
+// A dumb, controlled pair of <input type="date"> inputs plus a row of
+// quick-range chips ("7 ימים", "חודש", "רבעון", "שנה"). Emits ISO dates
+// (YYYY-MM-DD) through onChange so callers can forward straight to
+// report endpoints.
+//
+// Usage:
+//   const [from, setFrom] = useState(null);
+//   const [to, setTo]   = useState(null);
+//   <DateRangePicker
+//     from={from}
+//     to={to}
+//     onChange={({ from, to }) => { setFrom(from); setTo(to); }}
+//   />
+
+const QUICK_RANGES = [
+  { key: '7d',  label: '7 ימים',  days: 7 },
+  { key: '30d', label: 'חודש',    days: 30 },
+  { key: '90d', label: 'רבעון',  days: 90 },
+  { key: '1y',  label: 'שנה',     days: 365 },
+];
+
+function toISODate(d) {
+  // Format as YYYY-MM-DD in local time (matches <input type="date">).
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+export default function DateRangePicker({
+  from = '',
+  to = '',
+  onChange,
+  'aria-label': ariaLabel = 'טווח תאריכים',
+}) {
+  const handleFrom = (v) => onChange?.({ from: v || '', to });
+  const handleTo   = (v) => onChange?.({ from, to: v || '' });
+
+  const applyQuick = (days) => {
+    const end = new Date();
+    const start = new Date();
+    start.setDate(start.getDate() - days);
+    onChange?.({ from: toISODate(start), to: toISODate(end) });
+  };
+
+  const clear = () => onChange?.({ from: '', to: '' });
+
+  return (
+    <div className="drp-root" role="group" aria-label={ariaLabel} dir="rtl">
+      <div className="drp-fields">
+        <label className="drp-field">
+          <span className="drp-label">מתאריך</span>
+          <input
+            type="date"
+            value={from || ''}
+            onChange={(e) => handleFrom(e.target.value)}
+            className="drp-input"
+            aria-label="מתאריך"
+          />
+        </label>
+        <label className="drp-field">
+          <span className="drp-label">עד תאריך</span>
+          <input
+            type="date"
+            value={to || ''}
+            onChange={(e) => handleTo(e.target.value)}
+            className="drp-input"
+            aria-label="עד תאריך"
+          />
+        </label>
+      </div>
+      <div className="drp-chips" role="group" aria-label="טווחים מהירים">
+        {QUICK_RANGES.map((r) => (
+          <button
+            key={r.key}
+            type="button"
+            className="drp-chip"
+            onClick={() => applyQuick(r.days)}
+          >
+            {r.label}
+          </button>
+        ))}
+        {(from || to) && (
+          <button
+            type="button"
+            className="drp-chip drp-chip-clear"
+            onClick={clear}
+            aria-label="נקה טווח"
+          >
+            נקה
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/DeltaBadge.css
+++ b/frontend/src/components/DeltaBadge.css
@@ -1,0 +1,63 @@
+/* DeltaBadge — small pill next to KPI tiles showing rolling change.
+   Follows the chip style: rounded, neutral border, tonal fill that
+   matches existing `--success-*` / `--danger-*` / muted tokens so we
+   don't invent a new color system. Sized small enough to sit inline
+   with a stat value without reflowing the card. */
+
+.delta-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  font-family: var(--font-body);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.4;
+  white-space: nowrap;
+  /* sit next to the stat-value without pulling the label row down */
+  vertical-align: middle;
+  margin-inline-start: 6px;
+}
+
+.delta-badge .delta-num {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+}
+
+.delta-badge .delta-label {
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+/* Tone variants — reuse the same `--success` / `--danger` tokens the
+   rest of the app uses for positive/negative signal, so a color-blind
+   agent gets the same palette across the product. */
+.delta-badge.delta-up {
+  color: var(--success);
+  background: var(--success-bg);
+  border-color: color-mix(in srgb, var(--success) 30%, transparent);
+}
+
+.delta-badge.delta-down {
+  color: var(--danger);
+  background: var(--danger-bg);
+  border-color: color-mix(in srgb, var(--danger) 30%, transparent);
+}
+
+.delta-badge.delta-neutral {
+  color: var(--text-muted);
+  background: var(--bg-elevated);
+  border-color: var(--border);
+}
+
+/* When a DeltaBadge sits inside a tonal tile (`.delta-up .delta-label`
+   etc.), let the label pick up the tone too so "השבוע" doesn't read
+   gray against a green pill. */
+.delta-badge.delta-up .delta-label,
+.delta-badge.delta-down .delta-label {
+  color: inherit;
+  opacity: 0.78;
+}

--- a/frontend/src/components/DeltaBadge.jsx
+++ b/frontend/src/components/DeltaBadge.jsx
@@ -1,0 +1,65 @@
+// DeltaBadge — small pill that shows a rolling KPI change, e.g.
+// "+3 השבוע" or "−2 החודש". Used on the Dashboard next to each stat
+// card so an agent sees not just the current total but how it moved
+// over the last window.
+//
+// Contract:
+//   <DeltaBadge value={3} label="השבוע" />              → green "+3 השבוע"
+//   <DeltaBadge value={-2} label="החודש" />             → red "−2 החודש"
+//   <DeltaBadge value={0} label="השבוע" />              → gray "0 השבוע"
+//   <DeltaBadge value={3} label="x" direction="neutral" → overrides sign
+//
+// Accessibility:
+//   - role="status" so VoiceOver announces changes when the value
+//     updates after a period switch.
+//   - An sr-only sentence ("גידול של 3 לעומת השבוע הקודם") explains
+//     what the sign means; the visible pill shows just the signed
+//     number to keep the KPI row compact.
+import './DeltaBadge.css';
+
+function directionFromValue(v) {
+  if (v > 0) return 'up';
+  if (v < 0) return 'down';
+  return 'neutral';
+}
+
+// Visual minus uses U+2212 (Unicode minus) instead of ASCII "-", which
+// is thinner and visually noisy next to a digit in Hebrew display fonts.
+function formatSigned(v) {
+  if (v > 0) return `+${v}`;
+  if (v < 0) return `−${Math.abs(v)}`;
+  return '0';
+}
+
+function srSentence(v, label) {
+  // label is already a period word like "השבוע" / "החודש" / "הרבעון".
+  // The sentence reads as "גידול של 3 לעומת השבוע הקודם", which is how
+  // native Hebrew speakers phrase comparative deltas.
+  const periodPrev = label
+    .replace(/^ה/, 'ה') // noop — keeps the definite article
+    .replace(/השבוע/, 'השבוע הקודם')
+    .replace(/החודש/, 'החודש הקודם')
+    .replace(/הרבעון/, 'הרבעון הקודם');
+  if (v > 0) return `גידול של ${v} לעומת ${periodPrev}`;
+  if (v < 0) return `ירידה של ${Math.abs(v)} לעומת ${periodPrev}`;
+  return `ללא שינוי לעומת ${periodPrev}`;
+}
+
+export default function DeltaBadge({ value, label, direction }) {
+  const num = Number.isFinite(Number(value)) ? Number(value) : 0;
+  const dir = direction || directionFromValue(num);
+  const visible = formatSigned(num);
+  const sr = srSentence(num, label);
+
+  return (
+    <span
+      className={`delta-badge delta-${dir}`}
+      role="status"
+      dir="rtl"
+    >
+      <span className="delta-num" aria-hidden="true">{visible}</span>
+      <span className="delta-label" aria-hidden="true">{label}</span>
+      <span className="sr-only">{sr}</span>
+    </span>
+  );
+}

--- a/frontend/src/components/FavoriteStar.css
+++ b/frontend/src/components/FavoriteStar.css
@@ -1,0 +1,48 @@
+/* Sprint 7 / MLS parity — B4. Minimal visual for the reusable favorite
+ * toggle. Tone: amber-gold when active; neutral outline when not. No
+ * new btn-* classes — this is a bare icon button. */
+
+.fav-star {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-muted, #8a8a93);
+  cursor: pointer;
+  transition: color 120ms ease, transform 120ms ease, background-color 120ms ease;
+}
+
+.fav-star:hover {
+  background: var(--surface-hover, rgba(0, 0, 0, 0.04));
+  color: var(--gold, #d4a017);
+}
+
+.fav-star:focus-visible {
+  outline: 2px solid var(--focus-ring, #7a6cff);
+  outline-offset: 2px;
+}
+
+.fav-star.is-active {
+  color: var(--gold, #d4a017);
+}
+
+.fav-star.is-active:hover {
+  color: var(--gold-strong, #b8890f);
+}
+
+.fav-star[data-busy] {
+  opacity: 0.6;
+  cursor: progress;
+}
+
+/* Very small star variant for dense table rows. */
+.fav-star.fav-star-sm {
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+}

--- a/frontend/src/components/FavoriteStar.jsx
+++ b/frontend/src/components/FavoriteStar.jsx
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+import { Star } from 'lucide-react';
+import './FavoriteStar.css';
+
+// Sprint 7 / MLS parity — Task B4. Reusable star-toggle for any entity
+// (lead, property, owner, …). The parent owns the active state and
+// provides onToggle(nextActive); the component is presentational so
+// the same instance works equally well on a card, a row, a header.
+//
+// Why a button (not an input/checkbox):
+// - We want the full pressed/unpressed a11y semantics via aria-pressed.
+// - A checkbox would carry a <label> that competes with the parent
+//   card's own click target on mobile (customer row tap → detail page).
+//
+// The component stops click propagation — favoriting a card should
+// never also navigate the card's link. Hosts that actually want the
+// bubble can wrap the star in a non-clickable span.
+export default function FavoriteStar({
+  active = false,
+  onToggle,
+  size = 16,
+  className = '',
+  labelActive = 'הסר ממועדפים',
+  labelInactive = 'הוסף למועדפים',
+}) {
+  const [busy, setBusy] = useState(false);
+  const label = active ? labelActive : labelInactive;
+
+  const handleClick = async (e) => {
+    // Stop the click from bubbling to the row/card click handler.
+    e.stopPropagation();
+    if (busy) return;
+    setBusy(true);
+    try {
+      // Pass the next desired state so the caller can mirror its own
+      // optimistic update without recomputing `!active` in every host.
+      await onToggle?.(!active);
+    } catch {
+      // Errors are the host's responsibility — we surface them via the
+      // toast system there, not from this primitive.
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      className={`fav-star ${active ? 'is-active' : ''} ${className}`.trim()}
+      onClick={handleClick}
+      aria-pressed={active}
+      aria-label={label}
+      title={label}
+      data-busy={busy || undefined}
+    >
+      <Star
+        size={size}
+        strokeWidth={active ? 2 : 1.75}
+        aria-hidden="true"
+        fill={active ? 'currentColor' : 'none'}
+      />
+    </button>
+  );
+}

--- a/frontend/src/components/Layout.css
+++ b/frontend/src/components/Layout.css
@@ -814,3 +814,31 @@ img.agent-avatar {
   border-style: solid;
 }
 
+/* Sprint 7 B4 — sidebar favorites strip. Tighter than the main nav so
+   it reads as "stuff I starred" rather than primary navigation. */
+.nav-favorites .nav-section-label {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+.nav-favorite {
+  font-size: 13px;
+  padding-block: 7px;
+  color: var(--text-secondary);
+}
+.nav-favorite svg {
+  color: var(--gold);
+  flex-shrink: 0;
+}
+.nav-favorite-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.sidebar.collapsed .nav-favorites {
+  /* Collapsed rail doesn't have room for the favorites strip;
+     showing just heart icons would be confusing. Hide entirely — the
+     ⌘K palette is the collapsed-mode escape hatch. */
+  display: none;
+}
+

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -24,10 +24,16 @@ import {
   MessageCircle,
   Calculator,
   Download as DownloadIcon,
+  BarChart2,
+  Activity as ActivityIcon,
+  Bell,
+  Tag,
+  Heart,
 } from 'lucide-react';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '../lib/auth';
 import { useTheme } from '../lib/theme';
+import api from '../lib/api';
 import MobileTabBar from './MobileTabBar';
 import MobileMoreSheet from './MobileMoreSheet';
 
@@ -52,6 +58,16 @@ const navItems = [
 const quickActions = [
   { path: '/properties/new', icon: Plus, label: 'נכס חדש' },
   { path: '/customers/new', icon: UserPlus, label: 'ליד חדש' },
+];
+
+// Sprint 4 reporting surfaces + Sprint 1 A2 tag-settings entry point.
+// Collected in a "כלי ניהול" group so the main nav isn't cluttered; Office
+// (Sprint 7 A1) is gated to role === 'OWNER' — rendered conditionally below.
+const MANAGEMENT_ITEMS = [
+  { path: '/reports',       icon: BarChart2,   label: 'דוחות' },
+  { path: '/activity',      icon: ActivityIcon, label: 'פעילות' },
+  { path: '/reminders',     icon: Bell,         label: 'תזכורות' },
+  { path: '/settings/tags', icon: Tag,          label: 'ניהול תגיות' },
 ];
 
 // Pages that should show a back arrow + contextual title instead of the logo.
@@ -92,10 +108,66 @@ export default function Layout({ onLogout }) {
   const [copiedShare, setCopiedShare] = useState(false);
   const [dynamicTitle, setDynamicTitle] = useState('');
   const [headerHidden, setHeaderHidden] = useState(false);
+  const [favorites, setFavorites] = useState([]);
   const location = useLocation();
   const navigate = useNavigate();
   const { user } = useAuth();
   const { theme, toggle: toggleTheme } = useTheme();
+
+  const isOwner = user?.role === 'OWNER';
+
+  // Sprint 7 B4 — sidebar "המועדפים" strip.
+  // Hydrates each favorite's display label by cross-referencing the list
+  // endpoints (properties / leads / owners). Cached in component state;
+  // refetched on window focus so a favorite added in another tab shows
+  // up when the agent returns. Kept to 5 items max in the UI.
+  const loadFavorites = useCallback(async () => {
+    if (!user?.id) return;
+    try {
+      const favRes = await api.listFavorites();
+      const favItems = (favRes?.items || []).slice(0, 5);
+      if (favItems.length === 0) { setFavorites([]); return; }
+      const [propsRes, leadsRes, ownersRes] = await Promise.all([
+        api.listProperties({ mine: '1' }).catch(() => ({ items: [] })),
+        api.listLeads().catch(() => ({ items: [] })),
+        api.listOwners().catch(() => ({ items: [] })),
+      ]);
+      const byId = {
+        PROPERTY: new Map((propsRes?.items || []).map((p) => [p.id, p])),
+        LEAD:     new Map((leadsRes?.items || []).map((l) => [l.id, l])),
+        OWNER:    new Map((ownersRes?.items || []).map((o) => [o.id, o])),
+      };
+      const hydrated = favItems
+        .map((fav) => {
+          const entity = byId[fav.entityType]?.get(fav.entityId);
+          if (!entity) return null;
+          if (fav.entityType === 'PROPERTY') {
+            const street = [entity.street, entity.number].filter(Boolean).join(' ').trim();
+            const label = [street || entity.address || 'נכס', entity.city].filter(Boolean).join(', ');
+            return { key: `P-${fav.entityId}`, label, to: `/properties/${fav.entityId}` };
+          }
+          if (fav.entityType === 'LEAD') {
+            return { key: `L-${fav.entityId}`, label: entity.name || 'ליד', to: `/customers?selected=${fav.entityId}` };
+          }
+          if (fav.entityType === 'OWNER') {
+            return { key: `O-${fav.entityId}`, label: entity.name || 'בעל נכס', to: `/owners/${fav.entityId}` };
+          }
+          return null;
+        })
+        .filter(Boolean);
+      setFavorites(hydrated);
+    } catch {
+      // Fail silently — favorites are a nice-to-have; 401 will bounce
+      // via the api client already.
+    }
+  }, [user?.id]);
+
+  useEffect(() => { loadFavorites(); }, [loadFavorites]);
+  useEffect(() => {
+    const onFocus = () => loadFavorites();
+    window.addEventListener('focus', onFocus);
+    return () => window.removeEventListener('focus', onFocus);
+  }, [loadFavorites]);
 
   useEffect(() => {
     try { localStorage.setItem('estia-sidebar-collapsed', collapsed ? '1' : '0'); }
@@ -297,6 +369,66 @@ export default function Layout({ onLogout }) {
               </NavLink>
             ))}
           </div>
+
+          {/* Sprint 4 (reports, activity, reminders) + Sprint 1 A2 (tags)
+              + Sprint 7 A1 (office — OWNER only). Grouped so the main
+              nav isn't swamped with admin-ish surfaces. */}
+          <div className="nav-section">
+            <span className="nav-section-label">כלי ניהול</span>
+            {MANAGEMENT_ITEMS.map((item) => (
+              <NavLink
+                key={item.path}
+                to={item.path}
+                data-label={item.label}
+                className={({ isActive }) =>
+                  `nav-item ${isActive ? 'active' : ''}`
+                }
+                onClick={() => setSidebarOpen(false)}
+              >
+                <item.icon size={20} />
+                <span>{item.label}</span>
+              </NavLink>
+            ))}
+            {isOwner && (
+              <NavLink
+                to="/office"
+                data-label="משרד"
+                className={({ isActive }) =>
+                  `nav-item ${isActive ? 'active' : ''}`
+                }
+                onClick={() => setSidebarOpen(false)}
+              >
+                <Building2 size={20} />
+                <span>משרד</span>
+              </NavLink>
+            )}
+          </div>
+
+          {/* Sprint 7 B4 — sidebar favorites strip. Rendered only when
+              there is something to show; max 5 items. Each row links to
+              the favorited entity's detail page. */}
+          {favorites.length > 0 && (
+            <div className="nav-section nav-favorites">
+              <span className="nav-section-label">
+                <Heart size={12} style={{ marginInlineEnd: 4, verticalAlign: -1 }} />
+                המועדפים
+              </span>
+              {favorites.map((f) => (
+                <NavLink
+                  key={f.key}
+                  to={f.to}
+                  className={({ isActive }) =>
+                    `nav-item nav-favorite ${isActive ? 'active' : ''}`
+                  }
+                  onClick={() => setSidebarOpen(false)}
+                  title={f.label}
+                >
+                  <Heart size={14} />
+                  <span className="nav-favorite-label">{f.label}</span>
+                </NavLink>
+              ))}
+            </div>
+          )}
 
           <div className="nav-section">
             <span className="nav-section-label">פעולות מהירות</span>

--- a/frontend/src/components/LeadSearchProfilesEditor.css
+++ b/frontend/src/components/LeadSearchProfilesEditor.css
@@ -1,0 +1,116 @@
+/* LeadSearchProfilesEditor — scoped styles. Rows collapse by default to
+   keep leads with many profiles scannable. */
+
+.lsp-editor {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md, 10px);
+  padding: 16px;
+}
+
+.lsp-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.lsp-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--gold);
+}
+
+.lsp-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  padding: 0 6px;
+  height: 18px;
+  border-radius: 10px;
+  background: var(--gold-soft, rgba(212, 175, 55, 0.15));
+  color: var(--gold);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.lsp-loading,
+.lsp-error {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-muted);
+  font-size: 13px;
+  padding: 12px 4px;
+}
+.lsp-error { color: var(--danger, #b00020); }
+
+.lsp-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.lsp-row {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-card);
+  overflow: hidden;
+}
+
+.lsp-row-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 10px;
+  background: var(--bg-subtle, rgba(0, 0, 0, 0.02));
+}
+
+.lsp-row-toggle {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  padding: 4px 0;
+  min-width: 0;
+}
+
+.lsp-label-input {
+  flex: 1;
+  background: transparent;
+  border: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+  padding: 4px 6px;
+  border-radius: 4px;
+  min-width: 0;
+}
+.lsp-label-input:focus { background: var(--bg-card); outline: 2px solid var(--gold); }
+
+.lsp-row-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.lsp-row-body {
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}

--- a/frontend/src/components/LeadSearchProfilesEditor.jsx
+++ b/frontend/src/components/LeadSearchProfilesEditor.jsx
@@ -1,0 +1,373 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  Plus, Save, Trash2, ChevronDown, ChevronUp, Loader2, AlertCircle, Search,
+} from 'lucide-react';
+import api from '../lib/api';
+import { useToast } from '../lib/toast';
+import { NumberField, SelectField, Segmented } from './SmartFields';
+import EmptyState from './EmptyState';
+import './LeadSearchProfilesEditor.css';
+
+// ──────────────────────────────────────────────────────────────────
+// LeadSearchProfilesEditor — repeatable search-profile manager on a
+// lead (MLS K4). Each lead can define any number of "profiles" — a
+// named set of search criteria (label + domain + dealType + filters).
+// Adding a profile creates it server-side; saves are per-row via PATCH.
+//
+// Props:
+//   leadId     required
+//   onChange?  optional callback (profiles[]) => void after every mutation
+// ──────────────────────────────────────────────────────────────────
+
+const DOMAIN_OPTS = [
+  { value: '',             label: 'כל סוג' },
+  { value: 'RESIDENTIAL',  label: 'מגורים' },
+  { value: 'COMMERCIAL',   label: 'מסחרי' },
+];
+
+const DEAL_OPTS = [
+  { value: '',     label: 'הכל' },
+  { value: 'SALE', label: 'מכירה' },
+  { value: 'RENT', label: 'השכרה' },
+];
+
+const BOOL_REQ_KEYS = [
+  ['parkingReq',   'חניה'],
+  ['elevatorReq',  'מעלית'],
+  ['balconyReq',   'מרפסת'],
+  ['furnitureReq', 'ריהוט'],
+  ['mamadReq',     'ממ״ד'],
+  ['storeroomReq', 'מחסן'],
+];
+
+function emptyProfile() {
+  return {
+    label: '',
+    domain: '',
+    dealType: '',
+    propertyTypes: [],
+    cities: [],
+    neighborhoods: [],
+    streets: [],
+    minRoom: null,
+    maxRoom: null,
+    minPrice: null,
+    maxPrice: null,
+    minFloor: null,
+    maxFloor: null,
+    minBuilt: null,
+    maxBuilt: null,
+    parkingReq: false,
+    elevatorReq: false,
+    balconyReq: false,
+    furnitureReq: false,
+    mamadReq: false,
+    storeroomReq: false,
+  };
+}
+
+export default function LeadSearchProfilesEditor({ leadId, onChange }) {
+  const toast = useToast();
+  const [profiles, setProfiles] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [creating, setCreating] = useState(false);
+  const [expanded, setExpanded] = useState(() => new Set());
+
+  const load = useCallback(async () => {
+    if (!leadId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await api.listLeadSearchProfiles(leadId);
+      setProfiles(res?.items || []);
+    } catch (e) {
+      setError(e?.message || 'טעינת פרופילי חיפוש נכשלה');
+    } finally {
+      setLoading(false);
+    }
+  }, [leadId]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const create = async () => {
+    setCreating(true);
+    try {
+      const res = await api.createLeadSearchProfile(leadId, {
+        ...emptyProfile(),
+        label: 'חיפוש חדש',
+      });
+      const created = res?.profile || res;
+      setProfiles((p) => [...p, { ...emptyProfile(), ...created }]);
+      setExpanded((s) => new Set([...Array.from(s), created?.id]));
+      toast.success('פרופיל חיפוש נוסף');
+      onChange?.([...profiles, created]);
+    } catch (e) {
+      toast.error(e?.message || 'יצירה נכשלה');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const updateLocal = (id, patch) => {
+    setProfiles((list) => list.map((p) => (p.id === id ? { ...p, ...patch } : p)));
+  };
+
+  const save = async (profile) => {
+    try {
+      await api.updateLeadSearchProfile(leadId, profile.id, sanitize(profile));
+      toast.success('הפרופיל נשמר');
+      onChange?.(profiles);
+    } catch (e) {
+      toast.error(e?.message || 'שמירה נכשלה');
+    }
+  };
+
+  const remove = async (profile) => {
+    const previous = profiles;
+    setProfiles((list) => list.filter((p) => p.id !== profile.id));
+    try {
+      await api.deleteLeadSearchProfile(leadId, profile.id);
+      toast.info('הפרופיל נמחק');
+      onChange?.(profiles.filter((p) => p.id !== profile.id));
+    } catch (e) {
+      setProfiles(previous);
+      toast.error(e?.message || 'מחיקה נכשלה');
+    }
+  };
+
+  const toggle = (id) => {
+    setExpanded((s) => {
+      const next = new Set(Array.from(s));
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  return (
+    <section className="lsp-editor" aria-label="פרופילי חיפוש" dir="rtl">
+      <header className="lsp-header">
+        <h3 className="lsp-title">
+          <Search size={16} aria-hidden />
+          פרופילי חיפוש
+          {profiles.length > 0 && <span className="lsp-count">{profiles.length}</span>}
+        </h3>
+        <button
+          type="button"
+          className="btn btn-secondary btn-sm"
+          onClick={create}
+          disabled={creating || loading}
+        >
+          {creating ? <Loader2 size={14} className="y2-spin" aria-hidden /> : <Plus size={14} aria-hidden />}
+          פרופיל חדש
+        </button>
+      </header>
+
+      {loading ? (
+        <div className="lsp-loading" role="status">
+          <Loader2 size={16} className="y2-spin" aria-hidden />
+          טוען…
+        </div>
+      ) : error ? (
+        <div className="lsp-error" role="alert">
+          <AlertCircle size={14} aria-hidden />
+          {error}
+        </div>
+      ) : profiles.length === 0 ? (
+        <EmptyState
+          variant="filtered"
+          title="אין עדיין פרופילי חיפוש"
+          description="הוסף פרופיל חיפוש כדי לקבל התאמות מדויקות לנכסים."
+        />
+      ) : (
+        <ul className="lsp-list">
+          {profiles.map((p) => (
+            <ProfileRow
+              key={p.id}
+              profile={p}
+              expanded={expanded.has(p.id)}
+              onToggle={() => toggle(p.id)}
+              onChange={(patch) => updateLocal(p.id, patch)}
+              onSave={() => save(p)}
+              onDelete={() => remove(p)}
+            />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function sanitize(p) {
+  // Normalize empty strings → null for the enum fields; the backend
+  // expects null, not "".
+  return {
+    ...p,
+    domain: p.domain || null,
+    dealType: p.dealType || null,
+  };
+}
+
+function ProfileRow({ profile, expanded, onToggle, onChange, onSave, onDelete }) {
+  const labelId = `lsp-label-${profile.id}`;
+  return (
+    <li className="lsp-row">
+      <header className="lsp-row-head">
+        <button
+          type="button"
+          className="lsp-row-toggle"
+          onClick={onToggle}
+          aria-expanded={expanded}
+          aria-controls={`lsp-body-${profile.id}`}
+        >
+          {expanded ? <ChevronUp size={14} aria-hidden /> : <ChevronDown size={14} aria-hidden />}
+          <input
+            id={labelId}
+            className="lsp-label-input"
+            dir="auto"
+            placeholder="תן שם לחיפוש — למשל: גבעתיים 4ח׳"
+            value={profile.label || ''}
+            onChange={(e) => onChange({ label: e.target.value })}
+            onClick={(e) => e.stopPropagation()}
+            aria-label="שם הפרופיל"
+          />
+        </button>
+        <div className="lsp-row-actions">
+          <button type="button" className="btn btn-primary btn-sm" onClick={onSave} aria-label={`שמור פרופיל ${profile.label || ''}`}>
+            <Save size={14} aria-hidden />
+            שמור
+          </button>
+          <button type="button" className="btn btn-ghost btn-sm" onClick={onDelete} aria-label={`מחק פרופיל ${profile.label || ''}`}>
+            <Trash2 size={14} aria-hidden />
+          </button>
+        </div>
+      </header>
+
+      {expanded && (
+        <div id={`lsp-body-${profile.id}`} className="lsp-row-body">
+          <div className="form-row">
+            <div className="form-group">
+              <label className="form-label">סוג נכס</label>
+              <SelectField
+                value={profile.domain || ''}
+                onChange={(v) => onChange({ domain: v || null })}
+                options={DOMAIN_OPTS}
+              />
+            </div>
+            <div className="form-group">
+              <label className="form-label">סוג עסקה</label>
+              <Segmented
+                value={profile.dealType || ''}
+                onChange={(v) => onChange({ dealType: v || null })}
+                options={DEAL_OPTS}
+                ariaLabel="סוג עסקה"
+              />
+            </div>
+          </div>
+
+          <div className="form-row">
+            <div className="form-group">
+              <label className="form-label">ערים</label>
+              <CsvInput
+                value={profile.cities || []}
+                onChange={(arr) => onChange({ cities: arr })}
+                placeholder="תל אביב, רמת גן"
+                ariaLabel="ערים"
+              />
+            </div>
+            <div className="form-group">
+              <label className="form-label">שכונות</label>
+              <CsvInput
+                value={profile.neighborhoods || []}
+                onChange={(arr) => onChange({ neighborhoods: arr })}
+                placeholder="לב העיר, פלורנטין"
+                ariaLabel="שכונות"
+              />
+            </div>
+          </div>
+
+          <div className="form-row">
+            <div className="form-group">
+              <label className="form-label">חדרים מ-</label>
+              <NumberField value={profile.minRoom} onChange={(n) => onChange({ minRoom: n })} placeholder="3" />
+            </div>
+            <div className="form-group">
+              <label className="form-label">חדרים עד</label>
+              <NumberField value={profile.maxRoom} onChange={(n) => onChange({ maxRoom: n })} placeholder="5" />
+            </div>
+          </div>
+
+          <div className="form-row">
+            <div className="form-group">
+              <label className="form-label">מחיר מ-</label>
+              <NumberField value={profile.minPrice} onChange={(n) => onChange({ minPrice: n })} unit="₪" showShort />
+            </div>
+            <div className="form-group">
+              <label className="form-label">מחיר עד</label>
+              <NumberField value={profile.maxPrice} onChange={(n) => onChange({ maxPrice: n })} unit="₪" showShort />
+            </div>
+          </div>
+
+          <div className="form-row">
+            <div className="form-group">
+              <label className="form-label">קומה מ-</label>
+              <NumberField value={profile.minFloor} onChange={(n) => onChange({ minFloor: n })} />
+            </div>
+            <div className="form-group">
+              <label className="form-label">קומה עד</label>
+              <NumberField value={profile.maxFloor} onChange={(n) => onChange({ maxFloor: n })} />
+            </div>
+          </div>
+
+          <div className="form-row">
+            <div className="form-group">
+              <label className="form-label">שנת בנייה מ-</label>
+              <NumberField value={profile.minBuilt} onChange={(n) => onChange({ minBuilt: n })} placeholder="1980" />
+            </div>
+            <div className="form-group">
+              <label className="form-label">שנת בנייה עד</label>
+              <NumberField value={profile.maxBuilt} onChange={(n) => onChange({ maxBuilt: n })} placeholder="2025" />
+            </div>
+          </div>
+
+          <div className="checkbox-grid">
+            {BOOL_REQ_KEYS.map(([key, label]) => (
+              <label key={key} className="checkbox-item">
+                <input
+                  type="checkbox"
+                  checked={!!profile[key]}
+                  onChange={(e) => onChange({ [key]: e.target.checked })}
+                />
+                <span className="checkbox-custom" />
+                {label}
+              </label>
+            ))}
+          </div>
+        </div>
+      )}
+    </li>
+  );
+}
+
+// Minimal comma-separated text input → string[] helper. Keeps us from
+// adding a new chip-editor component just for two optional list fields.
+function CsvInput({ value, onChange, placeholder, ariaLabel }) {
+  const [text, setText] = useState((value || []).join(', '));
+  useEffect(() => { setText((value || []).join(', ')); }, [value]);
+  return (
+    <input
+      className="form-input"
+      dir="auto"
+      enterKeyHint="done"
+      placeholder={placeholder}
+      aria-label={ariaLabel}
+      value={text}
+      onChange={(e) => setText(e.target.value)}
+      onBlur={() => {
+        const arr = text.split(',').map((s) => s.trim()).filter(Boolean);
+        onChange(arr);
+      }}
+    />
+  );
+}

--- a/frontend/src/components/LeadSearchProfilesEditor.jsx
+++ b/frontend/src/components/LeadSearchProfilesEditor.jsx
@@ -5,6 +5,7 @@ import {
 import api from '../lib/api';
 import { useToast } from '../lib/toast';
 import { NumberField, SelectField, Segmented } from './SmartFields';
+import NeighborhoodPicker from './NeighborhoodPicker';
 import EmptyState from './EmptyState';
 import './LeadSearchProfilesEditor.css';
 
@@ -278,11 +279,13 @@ function ProfileRow({ profile, expanded, onToggle, onChange, onSave, onDelete })
             </div>
             <div className="form-group">
               <label className="form-label">שכונות</label>
-              <CsvInput
+              {/* MLS G1 — typeahead picker scoped to the profile's first
+                  city. When no city is set yet the picker shows a prompt
+                  and stays disabled. */}
+              <NeighborhoodPicker
+                city={(profile.cities || [])[0] || ''}
                 value={profile.neighborhoods || []}
                 onChange={(arr) => onChange({ neighborhoods: arr })}
-                placeholder="לב העיר, פלורנטין"
-                ariaLabel="שכונות"
               />
             </div>
           </div>

--- a/frontend/src/components/MatchingList.css
+++ b/frontend/src/components/MatchingList.css
@@ -1,0 +1,114 @@
+/* MatchingList — scoped styles. Rows are link-wrapped for quick nav. */
+
+.matching-list {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md, 10px);
+  padding: 16px;
+}
+
+.ml-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.ml-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--gold);
+}
+
+.ml-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  padding: 0 6px;
+  height: 18px;
+  border-radius: 10px;
+  background: var(--gold-soft, rgba(212, 175, 55, 0.15));
+  color: var(--gold);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.ml-loading,
+.ml-error {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-muted);
+  padding: 12px 4px;
+  font-size: 13px;
+}
+.ml-error { color: var(--danger, #b00020); }
+
+.ml-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
+
+.ml-row-link {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-card);
+  text-decoration: none;
+  color: inherit;
+}
+.ml-row-link:hover { border-color: var(--gold); background: var(--bg-hover, rgba(0, 0, 0, 0.02)); }
+.ml-row-static { cursor: default; }
+.ml-row-static:hover { border-color: var(--border); background: var(--bg-card); }
+
+.ml-score {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 1px;
+  flex-shrink: 0;
+  min-width: 44px;
+  justify-content: center;
+  padding: 6px 8px;
+  border-radius: 8px;
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 16px;
+  background: var(--bg-subtle, rgba(0, 0, 0, 0.04));
+  color: var(--text-muted);
+}
+.ml-score .ml-score-pct { font-size: 10px; margin-inline-start: 1px; }
+.ml-score-hot { background: rgba(220, 38, 38, 0.12); color: #b91c1c; }
+.ml-score-warm { background: rgba(234, 179, 8, 0.18); color: #a16207; }
+.ml-score-cold { background: rgba(59, 130, 246, 0.12); color: #1d4ed8; }
+
+.ml-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+  flex: 1;
+}
+.ml-name {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.ml-sub { font-size: 12px; color: var(--text-muted); }
+
+.ml-reasons {
+  list-style: disc;
+  padding-inline-start: 18px;
+  margin: 2px 0 0;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+.ml-reasons li { margin: 1px 0; }

--- a/frontend/src/components/MatchingList.jsx
+++ b/frontend/src/components/MatchingList.jsx
@@ -1,0 +1,143 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Sparkles, Loader2, AlertCircle, Building2, User } from 'lucide-react';
+import api from '../lib/api';
+import EmptyState from './EmptyState';
+import { displayPrice, displayText } from '../lib/display';
+import './MatchingList.css';
+
+// ──────────────────────────────────────────────────────────────────
+// MatchingList — read-only score + reasons list.
+//
+// Works for both directions:
+//   - leadId  → listing matching properties (property link per row)
+//   - propertyId → listing matching customers (lead link per row)
+//
+// Data shape (from the backend matching engine):
+//   { items: [{ id, score, reasons: string[], property?: {...}, lead?: {...} }] }
+// ──────────────────────────────────────────────────────────────────
+export default function MatchingList({
+  leadId,
+  propertyId,
+  limit = 10,
+  title,
+}) {
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const direction = leadId ? 'lead' : propertyId ? 'property' : null;
+  const resolvedTitle = title || (direction === 'lead' ? 'נכסים תואמים' : 'לקוחות תואמים');
+
+  const load = useCallback(async () => {
+    if (!direction) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = direction === 'lead'
+        ? await api.leadMatches(leadId)
+        : await api.propertyMatchingCustomers(propertyId);
+      const raw = res?.items || [];
+      setItems(limit ? raw.slice(0, limit) : raw);
+    } catch (e) {
+      setError(e?.message || 'טעינת התאמות נכשלה');
+    } finally {
+      setLoading(false);
+    }
+  }, [direction, leadId, propertyId, limit]);
+
+  useEffect(() => { load(); }, [load]);
+
+  return (
+    <section className="matching-list" aria-label={resolvedTitle} dir="rtl">
+      <header className="ml-header">
+        <h3 className="ml-title">
+          <Sparkles size={16} aria-hidden />
+          {resolvedTitle}
+          {items.length > 0 && <span className="ml-count">{items.length}</span>}
+        </h3>
+      </header>
+
+      {loading ? (
+        <div className="ml-loading" role="status">
+          <Loader2 size={16} className="y2-spin" aria-hidden />
+          <span>מחשב התאמות…</span>
+        </div>
+      ) : error ? (
+        <div className="ml-error" role="alert">
+          <AlertCircle size={14} aria-hidden />
+          <span>{error}</span>
+        </div>
+      ) : items.length === 0 ? (
+        <EmptyState
+          variant="filtered"
+          title="אין התאמות כרגע"
+          description={direction === 'lead'
+            ? 'נסה להרחיב את פרופיל החיפוש או להוסיף עיר נוספת.'
+            : 'נסה לעדכן את טווח המחיר או החדרים בנכס.'}
+        />
+      ) : (
+        <ul className="ml-list">
+          {items.map((m) => (
+            <MatchRow key={m.id || `${direction}-${Math.random()}`} match={m} direction={direction} />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function MatchRow({ match, direction }) {
+  const score = Math.round(Number(match.score || 0));
+  const reasons = Array.isArray(match.reasons) ? match.reasons : [];
+  const entity = direction === 'lead' ? match.property : match.lead;
+  const name = entity?.name || entity?.title || entity?.address || displayText(null);
+  const href = direction === 'lead'
+    ? (entity?.id ? `/properties/${entity.id}` : null)
+    : (entity?.id ? `/customers/${entity.id}` : null);
+  const Icon = direction === 'lead' ? Building2 : User;
+
+  const body = (
+    <>
+      <span className={`ml-score ${scoreTone(score)}`}>
+        <strong>{score}</strong>
+        <span className="ml-score-pct" aria-hidden>%</span>
+      </span>
+      <span className="ml-body">
+        <span className="ml-name">
+          <Icon size={12} aria-hidden />
+          {name}
+        </span>
+        {direction === 'lead' && entity?.price != null && (
+          <span className="ml-sub">{displayPrice(entity.price)}</span>
+        )}
+        {direction === 'property' && entity?.phone && (
+          <span className="ml-sub">{entity.phone}</span>
+        )}
+        {reasons.length > 0 && (
+          <ul className="ml-reasons">
+            {reasons.map((r, i) => (
+              <li key={i}>{r}</li>
+            ))}
+          </ul>
+        )}
+      </span>
+    </>
+  );
+
+  return (
+    <li className="ml-row">
+      {href ? (
+        <Link to={href} className="ml-row-link">{body}</Link>
+      ) : (
+        <div className="ml-row-link ml-row-static">{body}</div>
+      )}
+    </li>
+  );
+}
+
+function scoreTone(score) {
+  if (score >= 80) return 'ml-score-hot';
+  if (score >= 50) return 'ml-score-warm';
+  return 'ml-score-cold';
+}

--- a/frontend/src/components/MatchingList.jsx
+++ b/frontend/src/components/MatchingList.jsx
@@ -1,0 +1,18 @@
+// Minimal stub — will be superseded by Agent B's implementation at
+// integration time.
+//
+// Props (must match Agent B's contract):
+//   leadId?: string      → calls api.leadMatches
+//   propertyId?: string  → calls api.propertyMatchingCustomers
+
+export default function MatchingList({ leadId, propertyId }) {
+  return (
+    <div
+      className="matching-list-stub"
+      data-lead-id={leadId || ''}
+      data-property-id={propertyId || ''}
+    >
+      <h3>התאמות</h3>
+    </div>
+  );
+}

--- a/frontend/src/components/MobileMoreSheet.jsx
+++ b/frontend/src/components/MobileMoreSheet.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { User, UserCircle, Sun, Moon, Share2, LogOut, UserPlus, Plus, Check, Search, ArrowLeftRight, FileText, Shield, Calculator, Download as DownloadIcon } from 'lucide-react';
+import { User, UserCircle, Sun, Moon, Share2, LogOut, UserPlus, Plus, Check, Search, ArrowLeftRight, FileText, Shield, Calculator, Download as DownloadIcon, BarChart2, Activity as ActivityIcon, Bell, Tag, Building2 } from 'lucide-react';
 
 const ADMIN_EMAILS = new Set(['talfuks1234@gmail.com']);
 import { useAuth } from '../lib/auth';
@@ -108,6 +108,40 @@ export default function MobileMoreSheet({ open, onClose, onOpenPalette }) {
               <span className="mms-chevron">›</span>
             </div>
           </header>
+
+          {/* Sprint 4 reporting surfaces + Sprint 1 A2 tag-settings +
+              Sprint 7 A1 office (OWNER-only). Desktop has these in the
+              "כלי ניהול" sidebar group; on mobile they live here so the
+              bottom tab bar stays at 5 slots. */}
+          <section className="mms-section">
+            <button className="mms-row" onClick={() => go('/reports')}>
+              <span className="mms-row-icon"><BarChart2 size={18} /></span>
+              <span className="mms-row-text"><strong>דוחות</strong><small>ביצועים, עסקאות, נכסים</small></span>
+              <span className="mms-arrow">›</span>
+            </button>
+            <button className="mms-row" onClick={() => go('/activity')}>
+              <span className="mms-row-icon"><ActivityIcon size={18} /></span>
+              <span className="mms-row-text"><strong>פעילות</strong><small>פיד כל השינויים במערכת</small></span>
+              <span className="mms-arrow">›</span>
+            </button>
+            <button className="mms-row" onClick={() => go('/reminders')}>
+              <span className="mms-row-icon"><Bell size={18} /></span>
+              <span className="mms-row-text"><strong>תזכורות</strong><small>מטלות ותזכורות עם מועד</small></span>
+              <span className="mms-arrow">›</span>
+            </button>
+            <button className="mms-row" onClick={() => go('/settings/tags')}>
+              <span className="mms-row-icon"><Tag size={18} /></span>
+              <span className="mms-row-text"><strong>ניהול תגיות</strong><small>תיוג לקוחות, נכסים, עסקאות</small></span>
+              <span className="mms-arrow">›</span>
+            </button>
+            {user?.role === 'OWNER' && (
+              <button className="mms-row" onClick={() => go('/office')}>
+                <span className="mms-row-icon"><Building2 size={18} /></span>
+                <span className="mms-row-text"><strong>המשרד שלי</strong><small>חברי משרד ותפקידים</small></span>
+                <span className="mms-arrow">›</span>
+              </button>
+            )}
+          </section>
 
           <section className="mms-section">
             <button className="mms-row primary" onClick={copyCatalog}>

--- a/frontend/src/components/NeighborhoodPicker.css
+++ b/frontend/src/components/NeighborhoodPicker.css
@@ -1,0 +1,130 @@
+/* MLS G1 · NeighborhoodPicker — multi-select chip typeahead. RTL. */
+.nbh-picker {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+}
+
+.nbh-picker-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.nbh-picker-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding-block: 3px;
+  padding-inline: 8px;
+  background: var(--surface-2, #f3f4f6);
+  border: 1px solid var(--border, #e5e7eb);
+  border-radius: 999px;
+  font-size: 12px;
+  color: var(--text, #111);
+}
+
+.nbh-picker-chip-x {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  margin-inline-start: 2px;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  border-radius: 999px;
+  cursor: pointer;
+  color: var(--text-muted, #6b7280);
+}
+
+.nbh-picker-chip-x:hover,
+.nbh-picker-chip-x:focus-visible {
+  background: var(--surface-3, #e5e7eb);
+  color: var(--text, #111);
+  outline: none;
+}
+
+.nbh-picker-input-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.nbh-picker-input {
+  width: 100%;
+}
+
+.nbh-picker-disabled .nbh-picker-input {
+  background: var(--surface-2, #f3f4f6);
+  cursor: not-allowed;
+}
+
+.nbh-picker-loader {
+  position: absolute;
+  inset-inline-end: 8px;
+  top: 50%;
+  width: 10px;
+  height: 10px;
+  margin-top: -5px;
+  border: 2px solid var(--border, #e5e7eb);
+  border-top-color: var(--primary, #2563eb);
+  border-radius: 999px;
+  animation: nbh-spin 0.8s linear infinite;
+}
+
+@keyframes nbh-spin {
+  to { transform: rotate(360deg); }
+}
+
+.nbh-picker-list {
+  position: absolute;
+  z-index: 40;
+  inset-block-start: calc(100% + 2px);
+  inset-inline-start: 0;
+  inset-inline-end: 0;
+  max-height: 240px;
+  overflow-y: auto;
+  margin: 0;
+  padding: 4px 0;
+  list-style: none;
+  background: var(--surface, #fff);
+  border: 1px solid var(--border, #e5e7eb);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+}
+
+.nbh-picker-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding-block: 6px;
+  padding-inline: 10px;
+  cursor: pointer;
+  color: var(--text, #111);
+  font-size: 13px;
+}
+
+.nbh-picker-item.is-active,
+.nbh-picker-item:hover {
+  background: var(--surface-2, #f3f4f6);
+}
+
+.nbh-picker-alias {
+  margin-inline-start: auto;
+  color: var(--text-muted, #6b7280);
+  font-size: 11px;
+}
+
+.nbh-picker-err {
+  padding-block: 6px;
+  padding-inline: 10px;
+  color: var(--danger, #c03);
+  font-size: 12px;
+}

--- a/frontend/src/components/NeighborhoodPicker.jsx
+++ b/frontend/src/components/NeighborhoodPicker.jsx
@@ -1,0 +1,209 @@
+import { useEffect, useRef, useState } from 'react';
+import { X, MapPin } from 'lucide-react';
+import { useNeighborhoodSuggestions } from '../hooks/useNeighborhoodSuggestions';
+import './NeighborhoodPicker.css';
+
+// MLS G1 · Multi-select neighborhood typeahead.
+//
+// Renders a chip list of the currently-picked neighborhood names plus an
+// input that suggests matches from /api/neighborhoods?city=…&search=….
+// Unselected free-text is accepted on Enter so the picker never blocks
+// an agent who's typing a neighborhood we don't have in our seed table.
+//
+// Props:
+//   city         string   — required context for suggestions. When empty
+//                           the input is disabled with a prompt.
+//   value        string[] — currently-selected names
+//   onChange(next: string[])
+//   placeholder  string?  — override the default
+//
+// Accessibility: the input exposes role=combobox with aria-expanded /
+// aria-controls, and each suggestion is role=option. Chip remove
+// buttons are labelled "הסר X" so screen-readers announce the target.
+export default function NeighborhoodPicker({
+  city,
+  value = [],
+  onChange,
+  placeholder,
+  id,
+}) {
+  const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const inputRef = useRef(null);
+
+  const cityTrim = (city || '').trim();
+  const disabled = !cityTrim;
+
+  const { items, loading, error } = useNeighborhoodSuggestions(
+    cityTrim,
+    query,
+  );
+
+  // Reset the open state + query when the city swaps so suggestions
+  // don't linger across cities. The effect only runs on city change.
+  useEffect(() => {
+    setQuery('');
+    setOpen(false);
+    setActiveIndex(-1);
+  }, [cityTrim]);
+
+  const listId = id ? `${id}-list` : 'nbh-picker-list';
+  const effectivePlaceholder =
+    placeholder ?? (disabled ? 'בחר עיר תחילה' : 'התחל להקליד שכונה…');
+
+  const addValue = (name) => {
+    const trimmed = (name || '').trim();
+    if (!trimmed) return;
+    if (value.includes(trimmed)) {
+      // Already picked — just clear the input so the agent can move on.
+      setQuery('');
+      setOpen(false);
+      setActiveIndex(-1);
+      return;
+    }
+    onChange?.([...value, trimmed]);
+    setQuery('');
+    setOpen(false);
+    setActiveIndex(-1);
+  };
+
+  const removeAt = (i) => {
+    const next = value.slice();
+    next.splice(i, 1);
+    onChange?.(next);
+  };
+
+  // Filter out already-selected items so the dropdown never offers the
+  // same row twice. Cheap to do in-render; `items` is typically small.
+  const suggestions = items.filter((x) => !value.includes(x.name));
+
+  const onKeyDown = (e) => {
+    if (e.key === 'Backspace' && !query && value.length) {
+      // Match the common chip-input behavior — Backspace on empty input
+      // pops the last chip.
+      e.preventDefault();
+      removeAt(value.length - 1);
+      return;
+    }
+    if (!open && e.key === 'ArrowDown' && suggestions.length) {
+      setOpen(true);
+      setActiveIndex(0);
+      e.preventDefault();
+      return;
+    }
+    if (!open) {
+      if (e.key === 'Enter' && query.trim()) {
+        e.preventDefault();
+        addValue(query);
+      }
+      return;
+    }
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActiveIndex((i) => Math.min(suggestions.length - 1, i + 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIndex((i) => Math.max(0, i - 1));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      if (activeIndex >= 0 && suggestions[activeIndex]) {
+        addValue(suggestions[activeIndex].name);
+      } else if (query.trim()) {
+        addValue(query);
+      }
+    } else if (e.key === 'Escape') {
+      setOpen(false);
+      setActiveIndex(-1);
+    }
+  };
+
+  return (
+    <div
+      className={`nbh-picker ${disabled ? 'nbh-picker-disabled' : ''}`}
+      dir="rtl"
+    >
+      {value.length > 0 && (
+        <ul className="nbh-picker-chips" aria-label="שכונות שנבחרו">
+          {value.map((name, i) => (
+            <li key={`${name}-${i}`} className="nbh-picker-chip">
+              <MapPin size={12} aria-hidden="true" />
+              <span>{name}</span>
+              <button
+                type="button"
+                className="nbh-picker-chip-x"
+                onClick={() => removeAt(i)}
+                aria-label={`הסר ${name}`}
+              >
+                <X size={12} aria-hidden="true" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="nbh-picker-input-wrap">
+        <input
+          ref={inputRef}
+          id={id}
+          type="text"
+          role="combobox"
+          className="form-input nbh-picker-input"
+          value={query}
+          disabled={disabled}
+          placeholder={effectivePlaceholder}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            // Open as soon as the user types — the list may still be
+            // loading; it'll fill in once the hook resolves.
+            if (!disabled) setOpen(true);
+          }}
+          onFocus={() => { if (!disabled && suggestions.length) setOpen(true); }}
+          onBlur={() => setTimeout(() => setOpen(false), 120)}
+          onKeyDown={onKeyDown}
+          aria-autocomplete="list"
+          aria-expanded={open}
+          aria-controls={listId}
+          aria-label="שכונות"
+          autoComplete="off"
+          autoCorrect="off"
+          spellCheck={false}
+        />
+        {loading && <span className="nbh-picker-loader" aria-hidden="true" />}
+      </div>
+
+      {open && !disabled && (suggestions.length > 0 || error) && (
+        <ul
+          id={listId}
+          className="nbh-picker-list"
+          role="listbox"
+          aria-label="הצעות שכונות"
+        >
+          {error && (
+            <li className="nbh-picker-err" role="alert">{error}</li>
+          )}
+          {suggestions.map((item, i) => (
+            <li
+              key={item.id || `${item.name}-${i}`}
+              role="option"
+              aria-selected={i === activeIndex}
+              className={`nbh-picker-item ${i === activeIndex ? 'is-active' : ''}`}
+              // onMouseDown instead of onClick — prevents the input's
+              // onBlur from closing the list before the click resolves.
+              onMouseDown={(e) => { e.preventDefault(); addValue(item.name); }}
+              onMouseEnter={() => setActiveIndex(i)}
+            >
+              <MapPin size={12} aria-hidden="true" />
+              <span>{item.name}</span>
+              {item.aliases?.length > 0 && (
+                <small className="nbh-picker-alias">
+                  {item.aliases.slice(0, 2).join(' · ')}
+                </small>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/PropertyAssigneesPanel.css
+++ b/frontend/src/components/PropertyAssigneesPanel.css
@@ -1,0 +1,77 @@
+/* PropertyAssigneesPanel — multi-agent assignment list for a property. */
+
+.pap-root {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.pap-add-row {
+  display: grid;
+  grid-template-columns: 1fr 150px auto;
+  gap: 10px;
+  align-items: end;
+}
+
+.pap-add-email .form-input {
+  width: 100%;
+}
+
+@media (max-width: 640px) {
+  .pap-add-row {
+    grid-template-columns: 1fr;
+  }
+}
+
+.pap-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.pap-item {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: var(--bg-subtle, #f7f7f8);
+  border: 1px solid var(--border-subtle, #e2e2e6);
+}
+
+.pap-item-main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.pap-item-name {
+  font-weight: 600;
+}
+
+.pap-item-email {
+  font-size: 12px;
+  color: var(--text-muted, #757575);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pap-item-role {
+  font-size: 12px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--bg-default, #fff);
+  border: 1px solid var(--border-subtle, #e2e2e6);
+  color: var(--text-muted, #555);
+}
+
+.pap-hint {
+  color: var(--text-muted, #757575);
+  font-size: 13px;
+  margin: 4px 0;
+}

--- a/frontend/src/components/PropertyAssigneesPanel.jsx
+++ b/frontend/src/components/PropertyAssigneesPanel.jsx
@@ -1,0 +1,163 @@
+import { useEffect, useState, useId } from 'react';
+import { Trash2, UserPlus } from 'lucide-react';
+import api from '../lib/api';
+import { SelectField } from './SmartFields';
+import EmptyState from './EmptyState';
+import { ASSIGNEE_ROLE_LABELS, labelsToOptions, labelFor } from '../lib/mlsLabels';
+import './PropertyAssigneesPanel.css';
+
+// J10 — multi-agent property assignment.
+//
+// Renders the list of CO_AGENT / OBSERVER users attached to a property
+// (the primaryAgent lives in the pipeline block) plus an inline
+// add-by-email + role-picker form. Backend rejects cross-office 403;
+// we surface that server message directly via the toast. The remove
+// button uses a plain button with an aria-label (no confirm dialog —
+// adding back is a single form fill).
+
+const ROLE_OPTIONS = labelsToOptions(ASSIGNEE_ROLE_LABELS);
+
+export default function PropertyAssigneesPanel({ propertyId, toast }) {
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [addEmail, setAddEmail] = useState('');
+  const [addRole, setAddRole] = useState('CO_AGENT');
+  const [adding, setAdding] = useState(false);
+  const [removingId, setRemovingId] = useState(null);
+  const emailId = useId();
+  const roleId = useId();
+
+  const load = async () => {
+    if (!propertyId) return;
+    setLoading(true);
+    try {
+      const res = await api.listPropertyAssignees(propertyId);
+      setItems(res?.items || []);
+    } catch (e) {
+      toast?.error?.(e?.message || 'טעינת שותפי הנכס נכשלה');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { load(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [propertyId]);
+
+  const submitAdd = async (e) => {
+    e?.preventDefault?.();
+    const email = addEmail.trim();
+    if (!email) return;
+    setAdding(true);
+    try {
+      // J10 backend accepts `userId`; resolve email → id first so the
+      // agent doesn't have to look it up. Reuses /transfers/agents/search.
+      const lookup = await api.searchAgentByEmail(email);
+      if (!lookup?.agent) {
+        toast?.error?.(lookup?.self ? 'זה אתה — לא ניתן לשייך את עצמך' : 'לא נמצא סוכן עם האימייל הזה');
+        return;
+      }
+      await api.addPropertyAssignee(propertyId, {
+        userId: lookup.agent.id,
+        role: addRole,
+      });
+      toast?.success?.(`${lookup.agent.displayName || email} שויך ל${labelFor(ASSIGNEE_ROLE_LABELS, addRole)}`);
+      setAddEmail('');
+      setAddRole('CO_AGENT');
+      await load();
+    } catch (e2) {
+      toast?.error?.(e2?.message || 'הוספת שותף נכשלה');
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  const remove = async (userId) => {
+    setRemovingId(userId);
+    try {
+      await api.removePropertyAssignee(propertyId, userId);
+      toast?.info?.('השותף הוסר');
+      await load();
+    } catch (e) {
+      toast?.error?.(e?.message || 'הסרת השותף נכשלה');
+    } finally {
+      setRemovingId(null);
+    }
+  };
+
+  return (
+    <section className="pap-root" aria-label="שותפים לנכס">
+      <form className="pap-add" onSubmit={submitAdd}>
+        <div className="pap-add-row">
+          <div className="form-group pap-add-email">
+            <label className="form-label" htmlFor={emailId}>אימייל שותף</label>
+            <input
+              id={emailId}
+              type="email"
+              className="form-input"
+              placeholder="partner@estia.app"
+              dir="ltr"
+              value={addEmail}
+              onChange={(e) => setAddEmail(e.target.value)}
+            />
+          </div>
+          <div className="form-group pap-add-role">
+            <label className="form-label" htmlFor={roleId}>תפקיד</label>
+            <SelectField
+              id={roleId}
+              value={addRole}
+              onChange={setAddRole}
+              options={ROLE_OPTIONS}
+              aria-label="תפקיד השותף"
+            />
+          </div>
+          <button
+            type="submit"
+            className="btn btn-primary"
+            disabled={adding || !addEmail.trim()}
+          >
+            <UserPlus size={14} aria-hidden="true" />
+            {adding ? 'מוסיף…' : 'הוסף שותף'}
+          </button>
+        </div>
+      </form>
+
+      {loading ? (
+        <p className="pap-hint">טוען…</p>
+      ) : items.length === 0 ? (
+        <EmptyState
+          title="אין שותפים משויכים"
+          description="הוסף שותף לפי אימייל כדי לחלוק את הנכס עם סוכן נוסף במשרד"
+          variant="first"
+        />
+      ) : (
+        <ul className="pap-list">
+          {items.map((a) => {
+            const uid = a.user?.id || a.userId;
+            const name = a.user?.displayName || a.user?.email || uid;
+            const role = labelFor(ASSIGNEE_ROLE_LABELS, a.role);
+            return (
+              <li key={uid} className="pap-item">
+                <div className="pap-item-main">
+                  <strong className="pap-item-name">{name}</strong>
+                  {a.user?.email && (
+                    <span className="pap-item-email" dir="ltr">{a.user.email}</span>
+                  )}
+                </div>
+                <span className="pap-item-role">{role}</span>
+                <button
+                  type="button"
+                  className="btn btn-ghost btn-sm pap-item-remove"
+                  onClick={() => remove(uid)}
+                  disabled={removingId === uid}
+                  aria-label={`הסר את ${name}`}
+                >
+                  <Trash2 size={14} aria-hidden="true" />
+                  {removingId === uid ? 'מסיר…' : 'הסר'}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/PropertyAssigneesPanel.jsx
+++ b/frontend/src/components/PropertyAssigneesPanel.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useId } from 'react';
+import { useCallback, useEffect, useState, useId } from 'react';
 import { Trash2, UserPlus } from 'lucide-react';
 import api from '../lib/api';
 import { SelectField } from './SmartFields';
@@ -27,7 +27,7 @@ export default function PropertyAssigneesPanel({ propertyId, toast }) {
   const emailId = useId();
   const roleId = useId();
 
-  const load = async () => {
+  const load = useCallback(async () => {
     if (!propertyId) return;
     setLoading(true);
     try {
@@ -38,9 +38,9 @@ export default function PropertyAssigneesPanel({ propertyId, toast }) {
     } finally {
       setLoading(false);
     }
-  };
+  }, [propertyId, toast]);
 
-  useEffect(() => { load(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [propertyId]);
+  useEffect(() => { load(); }, [load]);
 
   const submitAdd = async (e) => {
     e?.preventDefault?.();

--- a/frontend/src/components/PropertyPipelineBlock.css
+++ b/frontend/src/components/PropertyPipelineBlock.css
@@ -1,0 +1,74 @@
+/* PropertyPipelineBlock — the J9 broker pipeline form section. Used both
+   inside NewProperty (as a read/edit block) and inside PropertyDetail
+   (as an inline editor card). */
+
+.ppb-root {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.ppb-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.ppb-primary-lookup {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.ppb-primary-lookup .form-input {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.ppb-primary-chip {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  padding: 8px 12px;
+  border-radius: 10px;
+  background: var(--bg-subtle, #f5f5f5);
+  border: 1px solid var(--border-subtle, #e1e1e1);
+}
+
+.ppb-primary-chip strong {
+  font-weight: 600;
+}
+
+.ppb-primary-meta {
+  font-size: 12px;
+  color: var(--text-muted, #757575);
+  direction: ltr;
+}
+
+.ppb-primary-hint {
+  margin-block-start: 4px;
+  font-size: 12px;
+  color: var(--text-muted, #757575);
+}
+
+.ppb-notes-count {
+  display: block;
+  margin-block-start: 4px;
+  text-align: end;
+  font-size: 11px;
+  color: var(--text-muted, #757575);
+}
+
+.ppb-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.ppb-error {
+  color: var(--color-danger, #d32f2f);
+  font-size: 13px;
+  margin-inline-end: auto;
+}

--- a/frontend/src/components/PropertyPipelineBlock.jsx
+++ b/frontend/src/components/PropertyPipelineBlock.jsx
@@ -1,0 +1,267 @@
+import { useEffect, useState } from 'react';
+import { SelectField, NumberField } from './SmartFields';
+import api from '../lib/api';
+import {
+  PROPERTY_STAGE_LABELS,
+  SERIOUSNESS_LABELS,
+  ASSIGNEE_ROLE_LABELS,
+  labelsToOptions,
+  labelFor,
+} from '../lib/mlsLabels';
+import './PropertyPipelineBlock.css';
+
+// J9 pipeline block — the six broker-side pipeline fields rolled into a
+// single reusable form section:
+//
+//   stage · agentCommissionPct · primaryAgentId · exclusivityExpire
+//   sellerSeriousness · brokerNotes
+//
+// Used in two contexts:
+//   1) NewProperty (form=true) — a read/edit block inside the wizard.
+//      Parent owns the form state; we just render controls and bubble
+//      changes via onChange(key, value).
+//   2) PropertyDetail (form=false, inline editor) — the block PATCHes
+//      the property directly via api.updateProperty when the user hits
+//      "שמור". Used inside the "צנרת תיווך" dashboard card.
+//
+// The "primary agent" picker reuses the same /transfers/agents/search
+// endpoint the transfer dialog uses — email lookup only, no free-form
+// search, because cross-office assignments go through the assignees
+// panel.
+
+const STAGE_OPTIONS = labelsToOptions(PROPERTY_STAGE_LABELS);
+const SERIOUSNESS_OPTIONS = labelsToOptions(SERIOUSNESS_LABELS);
+
+export default function PropertyPipelineBlock({
+  // Parent-driven form mode (NewProperty). When `form` is provided we
+  // read from it and never call the API; parent supplies onChange.
+  form,
+  onChange,
+  // Inline edit mode (PropertyDetail). Requires `property` to hydrate
+  // initial values and calls api.updateProperty on save.
+  property,
+  onSaved,
+  toast,
+}) {
+  const controlled = !!form;
+  const [local, setLocal] = useState(() => ({
+    stage: property?.stage || 'WATCHING',
+    agentCommissionPct: property?.agentCommissionPct ?? null,
+    primaryAgentId: property?.primaryAgentId || null,
+    exclusivityExpire: property?.exclusivityExpire
+      ? String(property.exclusivityExpire).slice(0, 10)
+      : '',
+    sellerSeriousness: property?.sellerSeriousness || 'NONE',
+    brokerNotes: property?.brokerNotes || '',
+  }));
+  const [primaryAgent, setPrimaryAgent] = useState(property?.primaryAgent || null);
+  const [agentLookupEmail, setAgentLookupEmail] = useState('');
+  const [lookupBusy, setLookupBusy] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  // Hydrate local state whenever the parent property changes (post-save
+  // reload). Only runs in inline mode.
+  useEffect(() => {
+    if (controlled || !property) return;
+    setLocal({
+      stage: property.stage || 'WATCHING',
+      agentCommissionPct: property.agentCommissionPct ?? null,
+      primaryAgentId: property.primaryAgentId || null,
+      exclusivityExpire: property.exclusivityExpire
+        ? String(property.exclusivityExpire).slice(0, 10)
+        : '',
+      sellerSeriousness: property.sellerSeriousness || 'NONE',
+      brokerNotes: property.brokerNotes || '',
+    });
+    setPrimaryAgent(property.primaryAgent || null);
+  }, [controlled, property]);
+
+  // Read current values from either the parent form or the local state
+  // so the render path is identical in both modes.
+  const v = controlled ? form : local;
+  const set = (key, value) => {
+    if (controlled) onChange?.(key, value);
+    else setLocal((p) => ({ ...p, [key]: value }));
+  };
+
+  const lookupAgent = async () => {
+    const email = agentLookupEmail.trim();
+    if (!email) {
+      toast?.error?.('הזן אימייל של הסוכן');
+      return;
+    }
+    setLookupBusy(true);
+    try {
+      const res = await api.searchAgentByEmail(email);
+      if (!res?.agent) {
+        toast?.error?.(res?.self ? 'זה אתה — לא ניתן לשייך את עצמך כסוכן ראשי' : 'לא נמצא סוכן עם האימייל הזה');
+        return;
+      }
+      setPrimaryAgent(res.agent);
+      set('primaryAgentId', res.agent.id);
+      setAgentLookupEmail('');
+      toast?.success?.(`${res.agent.displayName} סומן כסוכן ראשי`);
+    } catch (e) {
+      toast?.error?.(e?.message || 'חיפוש הסוכן נכשל');
+    } finally {
+      setLookupBusy(false);
+    }
+  };
+
+  const clearPrimaryAgent = () => {
+    setPrimaryAgent(null);
+    set('primaryAgentId', null);
+  };
+
+  const save = async () => {
+    if (controlled) return; // controlled mode has no internal save
+    if (!property?.id) return;
+    setError(null);
+    setSaving(true);
+    try {
+      const body = {
+        stage: v.stage,
+        agentCommissionPct: v.agentCommissionPct == null || v.agentCommissionPct === ''
+          ? null
+          : Number(v.agentCommissionPct),
+        primaryAgentId: v.primaryAgentId || null,
+        exclusivityExpire: v.exclusivityExpire
+          ? new Date(v.exclusivityExpire).toISOString()
+          : null,
+        sellerSeriousness: v.sellerSeriousness || 'NONE',
+        brokerNotes: v.brokerNotes || '',
+      };
+      await api.updateProperty(property.id, body);
+      toast?.success?.('צנרת התיווך עודכנה');
+      onSaved?.(body);
+    } catch (e) {
+      setError(e?.message || 'שמירה נכשלה');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <section className="ppb-root" aria-label="צנרת תיווך">
+      <div className="ppb-grid">
+        <div className="form-group">
+          <label className="form-label" htmlFor="ppb-stage">שלב</label>
+          <SelectField
+            id="ppb-stage"
+            value={v.stage}
+            onChange={(val) => set('stage', val)}
+            options={STAGE_OPTIONS}
+            aria-label="שלב הנכס"
+          />
+        </div>
+        <div className="form-group">
+          <label className="form-label" htmlFor="ppb-commission">עמלת סוכן (%)</label>
+          <NumberField
+            id="ppb-commission"
+            value={v.agentCommissionPct}
+            onChange={(val) => set('agentCommissionPct', val)}
+            unit="%"
+            min={0}
+            max={100}
+            placeholder="2"
+            aria-label="עמלת סוכן באחוזים"
+          />
+        </div>
+        <div className="form-group">
+          <label className="form-label" htmlFor="ppb-excl">תאריך סיום בלעדיות</label>
+          <input
+            id="ppb-excl"
+            type="date"
+            className="form-input"
+            value={v.exclusivityExpire}
+            onChange={(e) => set('exclusivityExpire', e.target.value)}
+            aria-label="תאריך סיום בלעדיות"
+          />
+        </div>
+        <div className="form-group">
+          <label className="form-label" htmlFor="ppb-seriousness">רצינות מוכר</label>
+          <SelectField
+            id="ppb-seriousness"
+            value={v.sellerSeriousness}
+            onChange={(val) => set('sellerSeriousness', val)}
+            options={SERIOUSNESS_OPTIONS}
+            aria-label="רצינות מוכר"
+          />
+        </div>
+      </div>
+
+      <div className="form-group ppb-primary">
+        <label className="form-label">סוכן ראשי</label>
+        {primaryAgent ? (
+          <div className="ppb-primary-chip">
+            <strong>{primaryAgent.displayName || primaryAgent.email}</strong>
+            {primaryAgent.email && <span className="ppb-primary-meta">{primaryAgent.email}</span>}
+            <button
+              type="button"
+              className="btn btn-ghost btn-sm"
+              onClick={clearPrimaryAgent}
+            >
+              נקה
+            </button>
+          </div>
+        ) : (
+          <div className="ppb-primary-lookup">
+            <input
+              type="email"
+              className="form-input"
+              placeholder="email@agent.com"
+              dir="ltr"
+              value={agentLookupEmail}
+              onChange={(e) => setAgentLookupEmail(e.target.value)}
+              aria-label="אימייל של הסוכן הראשי"
+            />
+            <button
+              type="button"
+              className="btn btn-secondary btn-sm"
+              onClick={lookupAgent}
+              disabled={lookupBusy || !agentLookupEmail.trim()}
+            >
+              {lookupBusy ? 'מחפש…' : 'חפש'}
+            </button>
+          </div>
+        )}
+        {v.primaryAgentId && !primaryAgent && (
+          <small className="ppb-primary-hint">
+            {labelFor(ASSIGNEE_ROLE_LABELS, 'CO_AGENT')} — מזהה: {v.primaryAgentId}
+          </small>
+        )}
+      </div>
+
+      <div className="form-group">
+        <label className="form-label" htmlFor="ppb-notes">הערות מתווך</label>
+        <textarea
+          id="ppb-notes"
+          className="form-textarea"
+          rows={3}
+          maxLength={4000}
+          dir="auto"
+          placeholder="הערות פנימיות — לא חשופות ללקוח"
+          value={v.brokerNotes}
+          onChange={(e) => set('brokerNotes', e.target.value)}
+          aria-label="הערות מתווך"
+        />
+        <small className="ppb-notes-count">{(v.brokerNotes || '').length}/4000</small>
+      </div>
+
+      {!controlled && (
+        <div className="ppb-actions">
+          {error && <span className="ppb-error" role="alert">{error}</span>}
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={save}
+            disabled={saving}
+          >
+            {saving ? 'שומר…' : 'שמור'}
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/RemindersPanel.css
+++ b/frontend/src/components/RemindersPanel.css
@@ -1,0 +1,125 @@
+/* RemindersPanel — scoped styles. Matches the card look of CustomerDetail
+   sections so it can embed as a sub-section without extra chrome. */
+
+.reminders-panel {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md, 10px);
+  padding: 16px;
+}
+
+.reminders-panel.is-compact { padding: 12px; }
+
+.rp-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.rp-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-display);
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--gold);
+  margin: 0;
+}
+
+.rp-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  padding: 0 6px;
+  height: 18px;
+  border-radius: 10px;
+  background: var(--gold-soft, rgba(212, 175, 55, 0.15));
+  color: var(--gold);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.rp-compose {
+  padding: 12px;
+  background: var(--bg-subtle, rgba(0, 0, 0, 0.02));
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  margin-bottom: 12px;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 10px;
+}
+
+.rp-compose-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.rp-loading,
+.rp-error {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-muted);
+  padding: 12px 4px;
+  font-size: 13px;
+}
+
+.rp-error { color: var(--danger, #b00020); }
+
+.rp-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.rp-item {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-card);
+}
+
+.rp-item-main { flex: 1; min-width: 0; }
+
+.rp-item-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 2px;
+}
+
+.rp-item-due {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.rp-item-notes {
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  white-space: pre-line;
+}
+
+.rp-item-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.rp-item.rp-status-completed .rp-item-title { text-decoration: line-through; color: var(--text-muted); }
+.rp-item.rp-status-cancelled { opacity: 0.65; }

--- a/frontend/src/components/RemindersPanel.jsx
+++ b/frontend/src/components/RemindersPanel.jsx
@@ -1,0 +1,239 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Bell, Plus, Check, X, Trash2, Loader2, AlertCircle } from 'lucide-react';
+import api from '../lib/api';
+import { useToast } from '../lib/toast';
+import EmptyState from './EmptyState';
+import { displayDate } from '../lib/display';
+import './RemindersPanel.css';
+
+// ──────────────────────────────────────────────────────────────────
+// RemindersPanel — entity-agnostic reminder list.
+//
+// Anchors via exactly one of `leadId`, `propertyId`, `customerId`. The
+// panel loads open reminders for that anchor, lets the agent compose a
+// new one inline, and surfaces per-row complete / cancel / delete
+// actions. No modal — the compose form drops into a disclosure region
+// so the common case (1-2 reminders on a detail page) stays one click.
+// ──────────────────────────────────────────────────────────────────
+export default function RemindersPanel({
+  leadId,
+  propertyId,
+  customerId,
+  title = 'תזכורות',
+  compact = false,
+}) {
+  const toast = useToast();
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [composeOpen, setComposeOpen] = useState(false);
+  const [composeBusy, setComposeBusy] = useState(false);
+  const [draft, setDraft] = useState({ title: '', dueAt: '', notes: '' });
+
+  const anchor = useMemo(() => {
+    if (leadId) return { leadId };
+    if (propertyId) return { propertyId };
+    if (customerId) return { customerId };
+    return null;
+  }, [leadId, propertyId, customerId]);
+
+  const refresh = useCallback(async () => {
+    if (!anchor) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await api.listReminders(anchor);
+      setItems(res?.items || []);
+    } catch (e) {
+      setError(e?.message || 'טעינת תזכורות נכשלה');
+    } finally {
+      setLoading(false);
+    }
+  }, [anchor]);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const submit = async (e) => {
+    e.preventDefault();
+    if (!draft.title.trim()) {
+      toast.error('הוסף כותרת לתזכורת');
+      return;
+    }
+    setComposeBusy(true);
+    try {
+      const body = {
+        title: draft.title.trim(),
+        dueAt: draft.dueAt ? new Date(draft.dueAt).toISOString() : null,
+        notes: draft.notes.trim() || null,
+        ...anchor,
+      };
+      await api.createReminder(body);
+      setDraft({ title: '', dueAt: '', notes: '' });
+      setComposeOpen(false);
+      toast.success('התזכורת נוספה');
+      await refresh();
+    } catch (err) {
+      toast.error(err?.message || 'יצירת התזכורת נכשלה');
+    } finally {
+      setComposeBusy(false);
+    }
+  };
+
+  const complete = async (rem) => {
+    try {
+      await api.completeReminder(rem.id);
+      toast.success('התזכורת סומנה כהושלמה');
+      await refresh();
+    } catch (e) { toast.error(e?.message || 'שמירה נכשלה'); }
+  };
+  const cancel = async (rem) => {
+    try {
+      await api.cancelReminder(rem.id);
+      toast.info('התזכורת בוטלה');
+      await refresh();
+    } catch (e) { toast.error(e?.message || 'שמירה נכשלה'); }
+  };
+  const remove = async (rem) => {
+    try {
+      await api.deleteReminder(rem.id);
+      toast.info('התזכורת נמחקה');
+      await refresh();
+    } catch (e) { toast.error(e?.message || 'מחיקה נכשלה'); }
+  };
+
+  return (
+    <section className={`reminders-panel ${compact ? 'is-compact' : ''}`} aria-label={title} dir="rtl">
+      <header className="rp-header">
+        <h3 className="rp-title">
+          <Bell size={16} aria-hidden />
+          {title}
+          {items.length > 0 && <span className="rp-count" aria-label={`${items.length} תזכורות`}>{items.length}</span>}
+        </h3>
+        <button
+          type="button"
+          className="btn btn-secondary btn-sm"
+          onClick={() => setComposeOpen((v) => !v)}
+          aria-expanded={composeOpen}
+        >
+          <Plus size={14} aria-hidden />
+          {composeOpen ? 'סגור' : 'תזכורת חדשה'}
+        </button>
+      </header>
+
+      {composeOpen && (
+        <form onSubmit={submit} className="rp-compose" aria-label="תזכורת חדשה">
+          <div className="form-group">
+            <label className="form-label" htmlFor="rp-title">כותרת</label>
+            <input
+              id="rp-title"
+              className="form-input"
+              dir="auto"
+              enterKeyHint="next"
+              value={draft.title}
+              onChange={(e) => setDraft((p) => ({ ...p, title: e.target.value }))}
+              placeholder="להתקשר בחמישי בבוקר"
+            />
+          </div>
+          <div className="form-group">
+            <label className="form-label" htmlFor="rp-due">תאריך יעד</label>
+            <input
+              id="rp-due"
+              type="datetime-local"
+              className="form-input"
+              value={draft.dueAt}
+              onChange={(e) => setDraft((p) => ({ ...p, dueAt: e.target.value }))}
+            />
+          </div>
+          <div className="form-group">
+            <label className="form-label" htmlFor="rp-notes">הערות</label>
+            <textarea
+              id="rp-notes"
+              className="form-textarea"
+              dir="auto"
+              rows={2}
+              value={draft.notes}
+              onChange={(e) => setDraft((p) => ({ ...p, notes: e.target.value }))}
+            />
+          </div>
+          <div className="rp-compose-actions">
+            <button type="submit" className="btn btn-primary btn-sm" disabled={composeBusy}>
+              {composeBusy ? <Loader2 size={14} className="y2-spin" aria-hidden /> : <Check size={14} aria-hidden />}
+              שמור
+            </button>
+            <button
+              type="button"
+              className="btn btn-ghost btn-sm"
+              onClick={() => { setComposeOpen(false); setDraft({ title: '', dueAt: '', notes: '' }); }}
+            >
+              ביטול
+            </button>
+          </div>
+        </form>
+      )}
+
+      {loading ? (
+        <div className="rp-loading" role="status">
+          <Loader2 size={16} className="y2-spin" aria-hidden />
+          <span>טוען תזכורות…</span>
+        </div>
+      ) : error ? (
+        <div className="rp-error" role="alert">
+          <AlertCircle size={14} aria-hidden />
+          <span>{error}</span>
+        </div>
+      ) : items.length === 0 ? (
+        <EmptyState
+          variant="filtered"
+          title="אין תזכורות פתוחות"
+          description="הוסף תזכורת כדי לא לשכוח לחזור ללקוח."
+        />
+      ) : (
+        <ul className="rp-list">
+          {items.map((r) => (
+            <li key={r.id} className={`rp-item rp-status-${(r.status || 'PENDING').toLowerCase()}`}>
+              <div className="rp-item-main">
+                <div className="rp-item-title">{r.title}</div>
+                {r.dueAt && (
+                  <div className="rp-item-due" title={r.dueAt}>
+                    {displayDate(r.dueAt)}
+                  </div>
+                )}
+                {r.notes && <div className="rp-item-notes">{r.notes}</div>}
+              </div>
+              <div className="rp-item-actions">
+                {r.status !== 'COMPLETED' && (
+                  <button
+                    type="button"
+                    className="btn btn-ghost btn-sm"
+                    onClick={() => complete(r)}
+                    aria-label={`סמן "${r.title}" כהושלם`}
+                  >
+                    <Check size={14} aria-hidden />
+                  </button>
+                )}
+                {r.status !== 'CANCELLED' && (
+                  <button
+                    type="button"
+                    className="btn btn-ghost btn-sm"
+                    onClick={() => cancel(r)}
+                    aria-label={`בטל "${r.title}"`}
+                  >
+                    <X size={14} aria-hidden />
+                  </button>
+                )}
+                <button
+                  type="button"
+                  className="btn btn-ghost btn-sm"
+                  onClick={() => remove(r)}
+                  aria-label={`מחק "${r.title}"`}
+                >
+                  <Trash2 size={14} aria-hidden />
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/RemindersPanel.jsx
+++ b/frontend/src/components/RemindersPanel.jsx
@@ -1,0 +1,17 @@
+// Minimal stub — will be superseded by Agent B's implementation at
+// integration time.
+//
+// Props (must match Agent B's contract):
+//   scope: { leadId?: string, propertyId?: string, customerId?: string }
+
+export default function RemindersPanel({ scope }) {
+  return (
+    <div
+      className="reminders-panel-stub"
+      data-scope={JSON.stringify(scope || {})}
+    >
+      <h3>תזכורות</h3>
+      <p>—</p>
+    </div>
+  );
+}

--- a/frontend/src/components/SavedSearchMenu.css
+++ b/frontend/src/components/SavedSearchMenu.css
@@ -1,0 +1,137 @@
+/* Sprint 7 / MLS parity — B3. Saved-search dropdown popover.
+ * Anchored below its trigger, slight shadow, fixed max-height so long
+ * lists scroll rather than push surrounding content. */
+
+.ss-menu {
+  position: relative;
+  display: inline-flex;
+}
+
+.ss-menu-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.ss-chev {
+  transition: transform 150ms ease;
+}
+
+.ss-chev.open {
+  transform: rotate(180deg);
+}
+
+.ss-menu-pop {
+  position: absolute;
+  top: calc(100% + 6px);
+  inset-inline-start: 0;
+  min-width: 280px;
+  max-width: 360px;
+  max-height: 60vh;
+  overflow: auto;
+  background: var(--surface, #fff);
+  border: 1px solid var(--border, rgba(0, 0, 0, 0.08));
+  border-radius: 10px;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.12);
+  padding: 10px;
+  z-index: 40;
+  animation: ss-menu-in 140ms ease;
+}
+
+@keyframes ss-menu-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.ss-menu-save-row {
+  display: flex;
+  gap: 6px;
+  padding-block-end: 8px;
+  border-bottom: 1px solid var(--border-subtle, rgba(0, 0, 0, 0.06));
+}
+
+.ss-menu-input {
+  flex: 1;
+  min-width: 0;
+  padding: 8px 10px;
+  border: 1px solid var(--border, rgba(0, 0, 0, 0.12));
+  border-radius: 8px;
+  background: var(--surface-muted, #fafafa);
+  font-size: 13px;
+  color: inherit;
+}
+
+.ss-menu-input:focus-visible {
+  outline: 2px solid var(--focus-ring, #7a6cff);
+  outline-offset: 1px;
+}
+
+.ss-menu-list {
+  padding-block-start: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.ss-menu-hint {
+  padding: 12px 10px;
+  color: var(--text-muted, #8a8a93);
+  font-size: 12px;
+  text-align: center;
+}
+
+.ss-menu-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  border-radius: 6px;
+  transition: background-color 120ms ease;
+}
+
+.ss-menu-row:hover {
+  background: var(--surface-hover, rgba(0, 0, 0, 0.04));
+}
+
+.ss-menu-load {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  color: inherit;
+  cursor: pointer;
+  font-size: 13px;
+  text-align: start;
+}
+
+.ss-menu-load:focus-visible {
+  outline: 2px solid var(--focus-ring, #7a6cff);
+  outline-offset: 1px;
+}
+
+.ss-menu-del {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted, #8a8a93);
+  cursor: pointer;
+  transition: background-color 120ms ease, color 120ms ease;
+}
+
+.ss-menu-del:hover {
+  background: var(--danger-soft, rgba(211, 47, 47, 0.08));
+  color: var(--danger, #d32f2f);
+}
+
+.ss-menu-del:focus-visible {
+  outline: 2px solid var(--focus-ring, #7a6cff);
+  outline-offset: 1px;
+}

--- a/frontend/src/components/SavedSearchMenu.jsx
+++ b/frontend/src/components/SavedSearchMenu.jsx
@@ -1,0 +1,175 @@
+import { useEffect, useRef, useState } from 'react';
+import { Bookmark, Trash2, ChevronDown } from 'lucide-react';
+import api from '../lib/api';
+import { useToast } from '../lib/toast';
+import './SavedSearchMenu.css';
+
+// Sprint 7 / MLS parity — Task B3. Saved-search dropdown for any list
+// page. Parent supplies the current filter object; the menu adds a
+// "name + save" input plus a list of existing snapshots with click-to-
+// load and trash-to-delete. Persists on the backend via
+// api.createSavedSearch / deleteSavedSearch so snapshots survive a reload.
+//
+// Props:
+//   entityType     - 'LEAD' | 'PROPERTY' | 'DEAL' | … (string; passed to API)
+//   currentFilters - plain JSON object representing the active filter set
+//   onLoad(filters)- invoked when the agent picks a saved entry
+//
+// The menu is not a modal — it's a floating popover anchored to its
+// trigger button. Outside click + Escape close it; focus returns to
+// the trigger.
+export default function SavedSearchMenu({ entityType, currentFilters, onLoad }) {
+  const [open, setOpen] = useState(false);
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [name, setName] = useState('');
+  const [saving, setSaving] = useState(false);
+  const wrapRef = useRef(null);
+  const toast = useToast();
+
+  // Fetch the saved-searches list each time the menu opens. Lists are
+  // tiny (a few rows per agent) so there's no cache layer; re-fetching
+  // keeps the menu fresh when other tabs or collaborators edit them.
+  useEffect(() => {
+    if (!open) return undefined;
+    let cancelled = false;
+    setLoading(true);
+    api.listSavedSearches(entityType)
+      .then((r) => {
+        if (cancelled) return;
+        setItems(r?.items || []);
+      })
+      .catch(() => { /* soft-fail: dropdown shows the empty state */ })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [open, entityType]);
+
+  // Close on outside click + Escape.
+  useEffect(() => {
+    if (!open) return undefined;
+    const onDocDown = (e) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target)) setOpen(false);
+    };
+    const onKey = (e) => { if (e.key === 'Escape') setOpen(false); };
+    document.addEventListener('mousedown', onDocDown);
+    document.addEventListener('touchstart', onDocDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDocDown);
+      document.removeEventListener('touchstart', onDocDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  const handleSave = async () => {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      toast.error('הזן שם לחיפוש');
+      return;
+    }
+    setSaving(true);
+    try {
+      const r = await api.createSavedSearch({
+        entityType,
+        name: trimmed,
+        filters: currentFilters || {},
+      });
+      const created = r?.savedSearch;
+      if (created) {
+        setItems((cur) => [created, ...cur]);
+      }
+      setName('');
+      toast.success('החיפוש נשמר');
+    } catch (e) {
+      toast.error(e?.message || 'שמירת החיפוש נכשלה');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (entry) => {
+    try {
+      await api.deleteSavedSearch(entry.id);
+      setItems((cur) => cur.filter((x) => x.id !== entry.id));
+      toast.success('החיפוש נמחק');
+    } catch (e) {
+      toast.error(e?.message || 'מחיקה נכשלה');
+    }
+  };
+
+  const handleLoad = (entry) => {
+    onLoad?.(entry.filters || {});
+    setOpen(false);
+  };
+
+  return (
+    <div className="ss-menu" ref={wrapRef}>
+      <button
+        type="button"
+        className="btn btn-ghost btn-sm ss-menu-trigger"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        aria-label="חיפושים שמורים"
+      >
+        <Bookmark size={14} aria-hidden="true" />
+        <span>חיפושים שמורים</span>
+        <ChevronDown size={14} aria-hidden="true" className={`ss-chev ${open ? 'open' : ''}`} />
+      </button>
+
+      {open && (
+        <div className="ss-menu-pop" role="menu" aria-label="חיפושים שמורים">
+          <div className="ss-menu-save-row">
+            <input
+              type="text"
+              className="ss-menu-input"
+              placeholder="שם לחיפוש החדש"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') handleSave(); }}
+              maxLength={80}
+            />
+            <button
+              type="button"
+              className="btn btn-primary btn-sm"
+              onClick={handleSave}
+              disabled={saving || !name.trim()}
+            >
+              שמור
+            </button>
+          </div>
+
+          <div className="ss-menu-list">
+            {loading && <div className="ss-menu-hint">טוען…</div>}
+            {!loading && items.length === 0 && (
+              <div className="ss-menu-hint">אין עדיין חיפושים שמורים</div>
+            )}
+            {!loading && items.map((entry) => (
+              <div key={entry.id} className="ss-menu-row">
+                <button
+                  type="button"
+                  className="ss-menu-load"
+                  onClick={() => handleLoad(entry)}
+                  role="menuitem"
+                  title={`טען את "${entry.name}"`}
+                >
+                  <Bookmark size={12} aria-hidden="true" />
+                  <span>{entry.name}</span>
+                </button>
+                <button
+                  type="button"
+                  className="ss-menu-del"
+                  onClick={() => handleDelete(entry)}
+                  aria-label={`מחק ${entry.name}`}
+                  title="מחק חיפוש"
+                >
+                  <Trash2 size={13} aria-hidden="true" />
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/TagPicker.css
+++ b/frontend/src/components/TagPicker.css
@@ -1,0 +1,115 @@
+/* TagPicker — scoped styles. Layout is chips + a "+ הוסף" trailing
+   button that opens a small popover. RTL-first. */
+
+.tag-picker {
+  display: block;
+}
+
+.tag-picker-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+.tag-picker-empty {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.tag-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--bg-card);
+  font-size: 12px;
+  line-height: 1.3;
+  color: var(--text-primary);
+  white-space: nowrap;
+}
+
+.tag-chip-label { font-weight: 500; }
+
+.tag-chip-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  padding: 0;
+  margin-inline-start: 2px;
+}
+.tag-chip-remove:hover { background: var(--bg-hover, rgba(0, 0, 0, 0.05)); }
+.tag-chip-remove:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.tag-picker-add-wrap {
+  position: relative;
+}
+
+.tag-picker-add {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 10px;
+  border-radius: 999px;
+  border: 1px dashed var(--border);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 12px;
+  cursor: pointer;
+}
+.tag-picker-add:hover { color: var(--text-primary); border-color: var(--gold); }
+.tag-picker-add:disabled { opacity: 0.6; cursor: not-allowed; }
+
+.tag-picker-pop {
+  position: absolute;
+  top: calc(100% + 4px);
+  inset-inline-start: 0;
+  min-width: 180px;
+  max-width: 260px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 6px);
+  box-shadow: var(--shadow-md, 0 4px 16px rgba(0, 0, 0, 0.12));
+  z-index: 20;
+  padding: 4px;
+}
+.tag-picker-pop ul { list-style: none; margin: 0; padding: 0; max-height: 240px; overflow-y: auto; }
+.tag-picker-pop-empty { padding: 8px 10px; color: var(--text-muted); font-size: 12px; }
+
+.tag-picker-pop-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 10px;
+  border: 0;
+  background: transparent;
+  border-radius: 4px;
+  text-align: start;
+  cursor: pointer;
+  font-size: 13px;
+  color: var(--text-primary);
+}
+.tag-picker-pop-item:hover { background: var(--bg-hover, rgba(0, 0, 0, 0.04)); }
+
+.tag-swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}

--- a/frontend/src/components/TagPicker.jsx
+++ b/frontend/src/components/TagPicker.jsx
@@ -1,0 +1,15 @@
+// Minimal stub — will be superseded by Agent B's implementation at
+// integration time. Kept small so my tests render, and so the UI
+// doesn't crash if Agent B's branch isn't merged yet.
+//
+// Props (must match Agent B's contract):
+//   entityType: 'PROPERTY' | 'LEAD' | 'CUSTOMER' | 'OWNER' | 'DEAL'
+//   entityId:   string
+
+export default function TagPicker({ entityType, entityId }) {
+  return (
+    <div className="tag-picker-stub" data-entity-type={entityType} data-entity-id={entityId}>
+      <span className="tag-picker-stub-label">תגיות</span>
+    </div>
+  );
+}

--- a/frontend/src/components/TagPicker.jsx
+++ b/frontend/src/components/TagPicker.jsx
@@ -1,0 +1,180 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Plus, X, Tag as TagIcon, Loader2 } from 'lucide-react';
+import api from '../lib/api';
+import { useToast } from '../lib/toast';
+import './TagPicker.css';
+
+// ──────────────────────────────────────────────────────────────────
+// TagPicker — entity-agnostic "tags / מדבקות" control.
+//
+// Renders the currently-assigned tags as chips + a "+" button that
+// opens a small dropdown listing the agent's remaining tags. Detach
+// happens inline on each chip via an X button. Works for any
+// entityType ('LEAD' | 'PROPERTY' | 'CUSTOMER') + entityId pair.
+//
+// Data flow:
+//   - On mount, load the agent's full tag catalog (api.listTags) + the
+//     subset already assigned to this entity (api.listAssignedTags).
+//   - Attach/detach optimistically update local state and then call
+//     api.assignTag / api.unassignTag. Failures roll back + toast.
+//
+// Props:
+//   entityType  'LEAD' | 'PROPERTY' | 'CUSTOMER'
+//   entityId    string (required)
+//   readonly    when true, only renders chips — no +/X buttons
+//   onChange    optional (tags[]) => void invoked after any change
+// ──────────────────────────────────────────────────────────────────
+export default function TagPicker({ entityType, entityId, readonly = false, onChange }) {
+  const toast = useToast();
+  const [allTags, setAllTags] = useState([]);
+  const [assigned, setAssigned] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [open, setOpen] = useState(false);
+  const [busyId, setBusyId] = useState(null);
+  const popRef = useRef(null);
+  const btnRef = useRef(null);
+
+  const refresh = useCallback(async () => {
+    if (!entityId) return;
+    setLoading(true);
+    try {
+      const [catalog, assignedRes] = await Promise.all([
+        api.listTags(),
+        api.listAssignedTags(entityType, entityId),
+      ]);
+      setAllTags(catalog?.items || []);
+      setAssigned(assignedRes?.items || []);
+    } catch (e) {
+      toast.error(e?.message || 'טעינת תגים נכשלה');
+    } finally {
+      setLoading(false);
+    }
+  }, [entityType, entityId, toast]);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  // Close the popover on outside click.
+  useEffect(() => {
+    if (!open) return undefined;
+    const onDoc = (e) => {
+      if (popRef.current?.contains(e.target)) return;
+      if (btnRef.current?.contains(e.target)) return;
+      setOpen(false);
+    };
+    document.addEventListener('mousedown', onDoc);
+    return () => document.removeEventListener('mousedown', onDoc);
+  }, [open]);
+
+  const available = useMemo(() => {
+    const taken = new Set(assigned.map((t) => t.id));
+    return allTags.filter((t) => !taken.has(t.id));
+  }, [allTags, assigned]);
+
+  const attach = async (tag) => {
+    setBusyId(tag.id);
+    const next = [...assigned, tag];
+    setAssigned(next);
+    setOpen(false);
+    try {
+      await api.assignTag(tag.id, { entityType, entityId });
+      onChange?.(next);
+    } catch (e) {
+      setAssigned(assigned);
+      toast.error(e?.message || 'הוספת התג נכשלה');
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const detach = async (tag) => {
+    setBusyId(tag.id);
+    const next = assigned.filter((t) => t.id !== tag.id);
+    setAssigned(next);
+    try {
+      await api.unassignTag(tag.id, entityType, entityId);
+      onChange?.(next);
+    } catch (e) {
+      setAssigned(assigned);
+      toast.error(e?.message || 'הסרת התג נכשלה');
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  return (
+    <div className="tag-picker" dir="rtl">
+      <ul className="tag-picker-list" aria-label="תגים משויכים">
+        {assigned.length === 0 && !loading && (
+          <li className="tag-picker-empty">
+            <TagIcon size={12} aria-hidden />
+            <span>אין תגים</span>
+          </li>
+        )}
+        {assigned.map((tag) => (
+          <li key={tag.id} className="tag-chip" style={chipStyle(tag.color)}>
+            <span className="tag-chip-label">{tag.name}</span>
+            {!readonly && (
+              <button
+                type="button"
+                className="tag-chip-remove"
+                aria-label={`הסר תג ${tag.name}`}
+                disabled={busyId === tag.id}
+                onClick={() => detach(tag)}
+              >
+                <X size={10} aria-hidden />
+              </button>
+            )}
+          </li>
+        ))}
+        {!readonly && (
+          <li className="tag-picker-add-wrap">
+            <button
+              ref={btnRef}
+              type="button"
+              className="tag-picker-add"
+              aria-label="הוסף תג"
+              aria-haspopup="listbox"
+              aria-expanded={open}
+              onClick={() => setOpen((v) => !v)}
+              disabled={loading}
+            >
+              {loading ? <Loader2 size={12} className="y2-spin" aria-hidden /> : <Plus size={12} aria-hidden />}
+              <span>הוסף</span>
+            </button>
+            {open && (
+              <div ref={popRef} className="tag-picker-pop" role="listbox" aria-label="בחר תג">
+                {available.length === 0 ? (
+                  <div className="tag-picker-pop-empty">אין תגים זמינים</div>
+                ) : (
+                  <ul>
+                    {available.map((tag) => (
+                      <li key={tag.id}>
+                        <button
+                          type="button"
+                          role="option"
+                          aria-selected="false"
+                          className="tag-picker-pop-item"
+                          onClick={() => attach(tag)}
+                        >
+                          <span className="tag-swatch" style={{ background: tag.color || 'var(--gold)' }} />
+                          <span>{tag.name}</span>
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            )}
+          </li>
+        )}
+      </ul>
+    </div>
+  );
+}
+
+function chipStyle(color) {
+  if (!color) return undefined;
+  // Soft-tint a hex color for the chip background. Keep it simple —
+  // if color isn't a #RRGGBB we fall back to the token default.
+  return { borderColor: color, color };
+}

--- a/frontend/src/hooks/useDashboardDeltas.js
+++ b/frontend/src/hooks/useDashboardDeltas.js
@@ -1,0 +1,109 @@
+// useDashboardDeltas — fan-out fetch of "new-properties / new-customers
+// / deals" over three rolling windows (7 / 30 / 90 days) so the
+// Dashboard can render a DeltaBadge next to each KPI tile.
+//
+// Contract:
+//   const { week, month, quarter, loading, error } = useDashboardDeltas(period);
+//
+//   period is the *visible* window selection ('week' | 'month' |
+//   'quarter'), used by callers that only want the active bucket. All
+//   three buckets are always fetched on mount so switching between
+//   periods doesn't re-hit the network — the Dashboard expects a
+//   single fan-out per mount, not one fetch per segmented-control tap.
+//
+//   Each bucket is shape: { properties, customers, deals } with counts.
+//   If a sub-call fails the corresponding slot is `null` (unknown) — the
+//   surrounding KPI tile still renders its total; only the pill goes
+//   blank. That matches the "degrade gracefully" requirement in the
+//   ticket: one broken endpoint must not blank the whole dashboard.
+//
+// Notes on cleanup:
+//   We guard every setState behind an `alive` ref so an unmount during
+//   flight doesn't write to a dead component. We don't need an
+//   AbortController here — the requests are cheap GETs and letting the
+//   network settle is simpler than plumbing signals through api.js.
+
+import { useEffect, useRef, useState } from 'react';
+import api from '../lib/api';
+
+const EMPTY_BUCKET = { properties: 0, customers: 0, deals: 0 };
+
+function toIso(ms) {
+  return new Date(ms).toISOString();
+}
+
+function windowRange(days) {
+  const now = Date.now();
+  return {
+    from: toIso(now - days * 86400000),
+    to: toIso(now),
+  };
+}
+
+// Resolve a report promise into a plain count; if the call rejects,
+// return `null` so the caller can render "unknown" without throwing.
+async function safeCount(promise) {
+  try {
+    const r = await promise;
+    const n = Number(r?.count);
+    return Number.isFinite(n) ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchBucket({ from, to }) {
+  const [properties, customers, deals] = await Promise.all([
+    safeCount(api.reportNewProperties({ from, to })),
+    safeCount(api.reportNewCustomers({ from, to })),
+    safeCount(api.reportDeals({ from, to })),
+  ]);
+  return { properties, customers, deals };
+}
+
+export default function useDashboardDeltas(_period = 'week') {
+  // `_period` is accepted for API ergonomics (so the Dashboard can
+  // pass the segmented-control value straight in) but the hook
+  // currently fetches all three windows on mount anyway. Keeping the
+  // arg in the signature means we can tighten this later without
+  // breaking callers.
+  const [state, setState] = useState({
+    week: EMPTY_BUCKET,
+    month: EMPTY_BUCKET,
+    quarter: EMPTY_BUCKET,
+    loading: true,
+    error: null,
+  });
+
+  const aliveRef = useRef(true);
+
+  useEffect(() => {
+    aliveRef.current = true;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const [week, month, quarter] = await Promise.all([
+          fetchBucket(windowRange(7)),
+          fetchBucket(windowRange(30)),
+          fetchBucket(windowRange(90)),
+        ]);
+        if (cancelled || !aliveRef.current) return;
+        setState({ week, month, quarter, loading: false, error: null });
+      } catch (err) {
+        // fetchBucket() already swallows per-call errors; reaching here
+        // means Promise.all itself rejected (shouldn't happen) — still
+        // surface a non-fatal error so the caller can show a toast.
+        if (cancelled || !aliveRef.current) return;
+        setState((prev) => ({ ...prev, loading: false, error: err }));
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      aliveRef.current = false;
+    };
+  }, []);
+
+  return state;
+}

--- a/frontend/src/hooks/useDashboardDeltas.js
+++ b/frontend/src/hooks/useDashboardDeltas.js
@@ -61,12 +61,14 @@ async function fetchBucket({ from, to }) {
   return { properties, customers, deals };
 }
 
-export default function useDashboardDeltas(_period = 'week') {
-  // `_period` is accepted for API ergonomics (so the Dashboard can
+export default function useDashboardDeltas(period = 'week') {
+  // `period` is accepted for API ergonomics (so the Dashboard can
   // pass the segmented-control value straight in) but the hook
   // currently fetches all three windows on mount anyway. Keeping the
   // arg in the signature means we can tighten this later without
-  // breaking callers.
+  // breaking callers. It's referenced below only to satisfy
+  // no-unused-vars; no-op at runtime.
+  void period;
   const [state, setState] = useState({
     week: EMPTY_BUCKET,
     month: EMPTY_BUCKET,

--- a/frontend/src/hooks/useNeighborhoodSuggestions.js
+++ b/frontend/src/hooks/useNeighborhoodSuggestions.js
@@ -1,0 +1,74 @@
+import { useEffect, useRef, useState } from 'react';
+import api from '../lib/api';
+
+// MLS G1 · Shared neighborhood-suggestions hook.
+//
+// Both AddressField (single-select) and NeighborhoodPicker (multi-select
+// chips) need the same "debounce → fetch /api/neighborhoods → cancel stale"
+// logic. Extracting it here keeps the two components skinny and makes
+// the async behavior independently testable.
+//
+// Inputs:
+//   city   string — required. Empty string/null skips the fetch entirely.
+//   query  string — the partial neighborhood name. Shorter than 1 char →
+//                    empty items, no fetch. We deliberately go low so the
+//                    list starts suggesting from the first Hebrew letter
+//                    (unlike the address field which needs 2 for Photon).
+//   opts.delayMs  number, default 200. Matches AddressField's original.
+//
+// Returns: { items, loading, error }.
+//   items   — the server's list verbatim ({id, city, name, aliases[]})
+//   loading — true while a request is in flight
+//   error   — null | Hebrew error string from the API envelope
+export function useNeighborhoodSuggestions(city, query, opts = {}) {
+  const { delayMs = 200 } = opts;
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  // Incrementing request-id guards against out-of-order fetches. The
+  // same pattern AddressField already uses — see its geoSearch effect.
+  const reqIdRef = useRef(0);
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => { mountedRef.current = false; };
+  }, []);
+
+  useEffect(() => {
+    const q = (query || '').trim();
+    const c = (city || '').trim();
+
+    // Nothing to fetch — reset visible state cleanly so a previous
+    // result doesn't stick around when the agent clears the city.
+    if (!c || q.length < 1) {
+      setItems([]);
+      setLoading(false);
+      setError(null);
+      return undefined;
+    }
+
+    const t = setTimeout(async () => {
+      const id = ++reqIdRef.current;
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await api.listNeighborhoods({ city: c, search: q });
+        if (!mountedRef.current || id !== reqIdRef.current) return;
+        setItems(res?.items || []);
+      } catch (e) {
+        if (!mountedRef.current || id !== reqIdRef.current) return;
+        setError(e?.message || 'טעינת שכונות נכשלה');
+        setItems([]);
+      } finally {
+        if (mountedRef.current && id === reqIdRef.current) setLoading(false);
+      }
+    }, delayMs);
+
+    return () => clearTimeout(t);
+  }, [city, query, delayMs]);
+
+  return { items, loading, error };
+}
+
+export default useNeighborhoodSuggestions;

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -404,6 +404,135 @@ export const api = {
   acceptTransfer: (id) => request(`/transfers/${id}/accept`, { method: 'POST' }),
   declineTransfer: (id) => request(`/transfers/${id}/decline`, { method: 'POST' }),
   cancelTransfer: (id) => request(`/transfers/${id}/cancel`, { method: 'POST' }),
+
+  // ─── MLS parity surface ────────────────────────────────────────────────
+  // Added as Phase 1 infrastructure for the multi-agent MLS UI build. All
+  // endpoints are owner-scoped on the server. Keep these grouped by
+  // feature so future renames land in one block.
+
+  // Office (A1)
+  getOffice:           () => request('/office'),
+  createOffice:        (body) => request('/office', { method: 'POST', body }),
+  updateOffice:        (body) => request('/office', { method: 'PATCH', body }),
+  addOfficeMember:     (body) => request('/office/members', { method: 'POST', body }),
+  removeOfficeMember:  (id) => request(`/office/members/${id}`, { method: 'DELETE' }),
+
+  // Tags (A2)
+  listTags:            () => request('/tags'),
+  createTag:           (body) => request('/tags', { method: 'POST', body }),
+  updateTag:           (id, body) => request(`/tags/${id}`, { method: 'PATCH', body }),
+  deleteTag:           (id) => request(`/tags/${id}`, { method: 'DELETE' }),
+  assignTag:           (tagId, { entityType, entityId }) =>
+    request(`/tags/${tagId}/assign`, { method: 'POST', body: { entityType, entityId } }),
+  unassignTag:         (tagId, entityType, entityId) =>
+    request(`/tags/${tagId}/assign/${entityType}/${entityId}`, { method: 'DELETE' }),
+  listAssignedTags:    (entityType, entityId) => {
+    const qs = new URLSearchParams({ entityType, entityId }).toString();
+    return request(`/tags/for?${qs}`);
+  },
+
+  // Reminders (D1)
+  listReminders:       (params = {}) => {
+    const qs = new URLSearchParams();
+    Object.entries(params).forEach(([k, v]) => {
+      if (v !== undefined && v !== null && v !== '') qs.set(k, String(v));
+    });
+    const s = qs.toString();
+    return request(`/reminders${s ? `?${s}` : ''}`);
+  },
+  createReminder:      (body) => request('/reminders', { method: 'POST', body }),
+  updateReminder:      (id, body) => request(`/reminders/${id}`, { method: 'PATCH', body }),
+  completeReminder:    (id) => request(`/reminders/${id}/complete`, { method: 'POST' }),
+  cancelReminder:      (id) => request(`/reminders/${id}/cancel`, { method: 'POST' }),
+  deleteReminder:      (id) => request(`/reminders/${id}`, { method: 'DELETE' }),
+
+  // LeadSearchProfile (K4)
+  listLeadSearchProfiles:   (leadId) => request(`/leads/${leadId}/search-profiles`),
+  createLeadSearchProfile:  (leadId, body) =>
+    request(`/leads/${leadId}/search-profiles`, { method: 'POST', body }),
+  updateLeadSearchProfile:  (leadId, id, body) =>
+    request(`/leads/${leadId}/search-profiles/${id}`, { method: 'PATCH', body }),
+  deleteLeadSearchProfile:  (leadId, id) =>
+    request(`/leads/${leadId}/search-profiles/${id}`, { method: 'DELETE' }),
+
+  // Matching (C3)
+  leadMatches:              (leadId) => request(`/leads/${leadId}/matches`),
+  propertyMatchingCustomers: (propertyId) => request(`/properties/${propertyId}/matching-customers`),
+
+  // Property assignees (J10)
+  listPropertyAssignees:    (propertyId) => request(`/properties/${propertyId}/assignees`),
+  addPropertyAssignee:      (propertyId, body) =>
+    request(`/properties/${propertyId}/assignees`, { method: 'POST', body }),
+  removePropertyAssignee:   (propertyId, userId) =>
+    request(`/properties/${propertyId}/assignees/${userId}`, { method: 'DELETE' }),
+
+  // Adverts (F1)
+  listAdverts:         (propertyId) => request(`/properties/${propertyId}/adverts`),
+  createAdvert:        (propertyId, body) =>
+    request(`/properties/${propertyId}/adverts`, { method: 'POST', body }),
+  updateAdvert:        (id, body) => request(`/adverts/${id}`, { method: 'PATCH', body }),
+  deleteAdvert:        (id) => request(`/adverts/${id}`, { method: 'DELETE' }),
+
+  // Global search (H1)
+  globalSearch:        (q, take) => {
+    const qs = new URLSearchParams({ q: q ?? '' });
+    if (take !== undefined && take !== null) qs.set('take', String(take));
+    return request(`/search?${qs.toString()}`);
+  },
+
+  // Activity feed (H3)
+  listActivity:        (params = {}) => {
+    const qs = new URLSearchParams();
+    Object.entries(params).forEach(([k, v]) => {
+      if (v !== undefined && v !== null && v !== '') qs.set(k, String(v));
+    });
+    const s = qs.toString();
+    return request(`/activity${s ? `?${s}` : ''}`);
+  },
+
+  // Reports (E1)
+  reportNewProperties:   (params = {}) => request(`/reports/new-properties${qsFrom(params)}`),
+  reportNewCustomers:    (params = {}) => request(`/reports/new-customers${qsFrom(params)}`),
+  reportDeals:           (params = {}) => request(`/reports/deals${qsFrom(params)}`),
+  reportViewings:        (params = {}) => request(`/reports/viewings${qsFrom(params)}`),
+  reportMarketingActions: (params = {}) => request(`/reports/marketing-actions${qsFrom(params)}`),
+  // B5 — CSV export URLs. Browser downloads need a plain URL (no fetch),
+  // so this returns the string and the caller sets window.location or an
+  // <a href>. `kind` is one of 'properties' | 'leads' | 'deals'.
+  exportUrl:           (kind) => `${BASE}/reports/export/${kind}.csv`,
+
+  // Neighborhoods (G1)
+  listNeighborhoods:   (params = {}) => request(`/neighborhoods${qsFrom(params)}`),
+  createNeighborhood:  (body) => request('/neighborhoods', { method: 'POST', body }),
+
+  // Saved searches (B3)
+  listSavedSearches:   (entityType) => {
+    const qs = entityType ? `?${new URLSearchParams({ entityType }).toString()}` : '';
+    return request(`/saved-searches${qs}`);
+  },
+  createSavedSearch:   (body) => request('/saved-searches', { method: 'POST', body }),
+  updateSavedSearch:   (id, body) => request(`/saved-searches/${id}`, { method: 'PATCH', body }),
+  deleteSavedSearch:   (id) => request(`/saved-searches/${id}`, { method: 'DELETE' }),
+
+  // Favorites (B4)
+  listFavorites:       (entityType) => {
+    const qs = entityType ? `?${new URLSearchParams({ entityType }).toString()}` : '';
+    return request(`/favorites${qs}`);
+  },
+  addFavorite:         (body) => request('/favorites', { method: 'POST', body }),
+  removeFavorite:      (entityType, entityId) =>
+    request(`/favorites/${entityType}/${entityId}`, { method: 'DELETE' }),
 };
+
+// Small querystring helper: drops empty values so `?from=&to=` doesn't
+// pollute server logs. Shared by the report endpoints.
+function qsFrom(params) {
+  const qs = new URLSearchParams();
+  Object.entries(params || {}).forEach(([k, v]) => {
+    if (v !== undefined && v !== null && v !== '') qs.set(k, String(v));
+  });
+  const s = qs.toString();
+  return s ? `?${s}` : '';
+}
 
 export default api;

--- a/frontend/src/lib/mlsLabels.js
+++ b/frontend/src/lib/mlsLabels.js
@@ -1,0 +1,88 @@
+// Hebrew labels for MLS-parity enum values.
+//
+// Mirrors backend/src/lib/mls-labels.ts. Kept as a separate frontend file
+// so we don't import across the backend/frontend boundary (TS → JS, and
+// backend bundles pull in pino/etc.). Keep the two files in sync when
+// values are added — the unit test in tests/unit/frontend/mlsLabels.test.js
+// asserts the maps cover every enum value the app renders.
+
+// ── Property lifecycle (Nadlan "שלב הנכס") ─────────────────────────
+export const PROPERTY_STAGE_LABELS = {
+  WATCHING:              'במעקב',
+  PRE_ACQUISITION:       'טרום-קליטה',
+  IN_PROGRESS:           'בתהליך',
+  SIGNED_NON_EXCLUSIVE:  'חתום — לא בלעדי',
+  SIGNED_EXCLUSIVE:      'חתום — בלעדי',
+  EXCLUSIVITY_ENDED:     'סיום בלעדיות',
+  REFUSED_BROKERAGE:     'סירב לתיווך',
+  REMOVED:               'הוסר',
+};
+
+// ── Property condition (J4) ────────────────────────────────────────
+export const PROPERTY_CONDITION_LABELS = {
+  NEW:               'חדש מקבלן',
+  AS_NEW:            'כחדש',
+  RENOVATED:         'משופצת',
+  PRESERVED:         'שמורה',
+  NEEDS_RENOVATION:  'דרוש שיפוץ',
+  NEEDS_TLC:         'דרוש רענון',
+  RAW:               'מעטפת',
+};
+
+// ── Seriousness (shared: Lead + Property.sellerSeriousness) ────────
+export const SERIOUSNESS_LABELS = {
+  NONE:    'ללא',
+  SORT_OF: 'סוג של',
+  MEDIUM:  'בינוני',
+  VERY:    'מאוד',
+};
+
+// ── Heating types (J6) ─────────────────────────────────────────────
+export const HEATING_TYPE_LABELS = {
+  gas:     'גז',
+  electric: 'חשמל',
+  solar:   'שמש',
+  floor:   'רצפתי',
+  central: 'מרכזי',
+};
+
+// ── Advert channels (F1) ───────────────────────────────────────────
+export const ADVERT_CHANNEL_LABELS = {
+  YAD2:      'יד2',
+  ONMAP:     'on map',
+  MADLAN:    'מדלן',
+  FACEBOOK:  'פייסבוק',
+  WHATSAPP:  'וואטסאפ',
+  INSTAGRAM: 'אינסטגרם',
+  WEBSITE:   'אתר',
+  OTHER:     'אחר',
+};
+
+// ── Advert statuses (F1) ───────────────────────────────────────────
+export const ADVERT_STATUS_LABELS = {
+  DRAFT:     'טיוטה',
+  PUBLISHED: 'פורסם',
+  PAUSED:    'מושהה',
+  EXPIRED:   'פג תוקף',
+  REMOVED:   'הוסר',
+};
+
+// ── Property assignee roles (J10) ──────────────────────────────────
+export const ASSIGNEE_ROLE_LABELS = {
+  CO_AGENT: 'שותף',
+  OBSERVER: 'צופה',
+};
+
+// Helper — turn a {VALUE: 'תווית'} map into the options array shape the
+// SelectField/Segmented components accept ([{value, label}, …]).
+export function labelsToOptions(map) {
+  return Object.entries(map).map(([value, label]) => ({ value, label }));
+}
+
+// Helper — look up a label with a safe fallback so raw enum values never
+// leak to the UI when the map is out of date. Returns the original
+// string when no entry exists rather than throwing.
+export function labelFor(map, value) {
+  if (value == null || value === '') return '';
+  return map[value] ?? String(value);
+}

--- a/frontend/src/lib/mlsLabels.js
+++ b/frontend/src/lib/mlsLabels.js
@@ -1,0 +1,63 @@
+// Sprint 2 / MLS parity — frontend-only copy of the Hebrew label
+// maps that Nadlan One uses. The backend equivalent lives in
+// backend/src/lib/mls-labels.ts; keep these in sync when adding new
+// enum values. Backend is the source of truth — this file exists so
+// the UI doesn't have to import from the backend package (we don't
+// share code across the server / client boundary in this repo).
+//
+// Keep flat (data-only) so it stays greppable.
+
+// Lead heat — thermal status.
+export const LEAD_HEAT_LABELS = {
+  HOT:  'חם',
+  WARM: 'חמים',
+  COLD: 'קר',
+};
+
+// Customer lifecycle (Nadlan "סטטוס לקוח").
+export const CUSTOMER_STATUS_LABELS = {
+  ACTIVE:    'פעיל',
+  INACTIVE:  'לא פעיל',
+  CANCELLED: 'מבוטל',
+  PAUSED:    'מושהה',
+  IN_DEAL:   'בעיסקה',
+  BOUGHT:    'רכש',
+  RENTED:    'שכר',
+};
+
+// Quick-lead status (Nadlan "LeadStatusID").
+export const QUICK_LEAD_STATUS_LABELS = {
+  NEW:                      'חדש',
+  INTENT_TO_CALL:           'בכוונת התקשרות',
+  CONVERTED:                'הומר',
+  DISQUALIFIED:             'נפסל',
+  NOT_INTERESTED:           'לא מעוניין',
+  IN_PROGRESS:              'בתהליך',
+  CONVERTED_NO_OPPORTUNITY: 'הומר, אין הזדמנות',
+  DELETED:                  'נמחק',
+  ARCHIVED:                 'ארכיון',
+};
+
+// Seriousness (shared: Lead + Property.sellerSeriousness).
+export const SERIOUSNESS_LABELS = {
+  NONE:    'ללא',
+  SORT_OF: 'סוג של',
+  MEDIUM:  'בינוני',
+  VERY:    'מאוד',
+};
+
+// Interest / property kind. Not from Nadlan but used in the filter
+// drawer so we keep the label list centralized.
+export const PROPERTY_TYPE_LABELS = {
+  residential: 'מגורים',
+  commercial:  'מסחרי',
+  land:        'קרקע',
+  office:      'משרד',
+  storage:     'מחסן',
+  parking:     'חניה',
+};
+
+// Small convenience: return [{value, label}] pairs for <select>/chip grids.
+export function labelOptions(map) {
+  return Object.entries(map).map(([value, label]) => ({ value, label }));
+}

--- a/frontend/src/lib/mlsLabels.js
+++ b/frontend/src/lib/mlsLabels.js
@@ -1,0 +1,61 @@
+// Hebrew labels for MLS-parity enum values.
+//
+// Mirrors backend/src/lib/mls-labels.ts. Kept as a separate frontend file
+// so we don't import across the backend/frontend boundary (TS → JS, and
+// backend bundles pull in pino/etc.). Keep the two files in sync when
+// values are added — the unit test in tests/unit/frontend/mlsLabels.test.js
+// asserts the maps cover every enum value the app renders.
+
+// ── Customer lifecycle (Nadlan "סטטוס לקוח") ────────────────────────
+export const CUSTOMER_STATUS_LABELS = {
+  ACTIVE:    'פעיל',
+  INACTIVE:  'לא פעיל',
+  CANCELLED: 'מבוטל',
+  PAUSED:    'מושהה',
+  IN_DEAL:   'בעיסקה',
+  BOUGHT:    'רכש',
+  RENTED:    'שכר',
+};
+
+// ── Quick-lead status (Nadlan "LeadStatusID") ───────────────────────
+export const QUICK_LEAD_STATUS_LABELS = {
+  NEW:                      'חדש',
+  INTENT_TO_CALL:           'בכוונת התקשרות',
+  CONVERTED:                'הומר',
+  DISQUALIFIED:             'נפסל',
+  NOT_INTERESTED:           'לא מעוניין',
+  IN_PROGRESS:              'בתהליך',
+  CONVERTED_NO_OPPORTUNITY: 'הומר, אין הזדמנות',
+  DELETED:                  'נמחק',
+  ARCHIVED:                 'ארכיון',
+};
+
+// ── Seriousness (shared: Lead + Property.sellerSeriousness) ─────────
+export const SERIOUSNESS_LABELS = {
+  NONE:    'ללא',
+  SORT_OF: 'סוג של',
+  MEDIUM:  'בינוני',
+  VERY:    'מאוד',
+};
+
+// ── Customer purpose ────────────────────────────────────────────────
+export const CUSTOMER_PURPOSE_LABELS = {
+  INVESTMENT:   'השקעה',
+  RESIDENCE:    'מגורים',
+  COMMERCIAL:   'מסחרי',
+  COMBINATION:  'משולב',
+};
+
+// Helper — turn a {VALUE: 'תווית'} map into the options array shape the
+// SelectField/Segmented components accept ([{value, label}, …]).
+export function labelsToOptions(map) {
+  return Object.entries(map).map(([value, label]) => ({ value, label }));
+}
+
+// Helper — look up a label with a safe fallback so raw enum values never
+// leak to the UI when the map is out of date. Returns the original
+// string when no entry exists rather than throwing.
+export function labelFor(map, value) {
+  if (value == null || value === '') return '';
+  return map[value] ?? String(value);
+}

--- a/frontend/src/pages/ActivityLog.css
+++ b/frontend/src/pages/ActivityLog.css
@@ -1,0 +1,160 @@
+.activity-page {
+  max-width: 980px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.activity-header { display: flex; flex-direction: column; gap: 4px; }
+
+.activity-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.activity-title h1 {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.activity-subtitle {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+.activity-filters {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.activity-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.activity-chip {
+  padding: 6px 12px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-family: var(--font-body);
+  font-size: 13px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.activity-chip.is-active {
+  background: var(--gold, #c9a14a);
+  color: var(--bg-primary, #fff);
+  border-color: var(--gold, #c9a14a);
+  font-weight: 700;
+}
+
+.activity-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.activity-limit {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.activity-limit select {
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg-card);
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: 13px;
+}
+
+.activity-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.activity-rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.activity-row {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.activity-row-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.activity-row-type {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--gold, #c9a14a);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.activity-row-action {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.activity-row-time {
+  font-size: 12px;
+  color: var(--text-tertiary, var(--text-secondary));
+  margin-inline-start: auto;
+}
+
+.activity-row-summary {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.activity-row-actor {
+  font-size: 12px;
+  color: var(--text-tertiary, var(--text-secondary));
+}
+
+.activity-row-skel {
+  height: 48px;
+  background: linear-gradient(90deg, var(--bg-elevated, #eee), var(--bg-card), var(--bg-elevated, #eee));
+  background-size: 200% 100%;
+  animation: activity-shimmer 1.4s infinite linear;
+  border-radius: 12px;
+}
+
+@keyframes activity-shimmer {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}

--- a/frontend/src/pages/ActivityLog.jsx
+++ b/frontend/src/pages/ActivityLog.jsx
@@ -1,0 +1,152 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Activity, RefreshCw } from 'lucide-react';
+import api from '../lib/api';
+import { useToast } from '../lib/toast';
+import { displayDateTime, displayText } from '../lib/display';
+import EmptyState from '../components/EmptyState';
+import './ActivityLog.css';
+
+// H3 — global activity timeline.
+//
+// Lists every activity entry across the authenticated agent's entities.
+// Filter chips narrow by entityType; the "limit" dropdown lets the
+// agent expand the window in 50-row steps. Endpoint is owner-scoped
+// on the backend.
+
+const ENTITY_FILTERS = [
+  { key: '',         label: 'הכל' },
+  { key: 'PROPERTY', label: 'נכסים' },
+  { key: 'LEAD',     label: 'לקוחות' },
+  { key: 'DEAL',     label: 'עסקאות' },
+  { key: 'OWNER',    label: 'בעלי נכסים' },
+  { key: 'REMINDER', label: 'תזכורות' },
+  { key: 'TAG',      label: 'תגיות' },
+];
+
+const LIMITS = [50, 100, 200, 500];
+
+export default function ActivityLog() {
+  const toast = useToast();
+  const [entityType, setEntityType] = useState('');
+  const [limit, setLimit] = useState(50);
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  const params = useMemo(() => {
+    const p = { limit };
+    if (entityType) p.entityType = entityType;
+    return p;
+  }, [entityType, limit]);
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const res = await api.listActivity(params);
+      setItems(res?.items || []);
+    } catch {
+      toast.error('שגיאה בטעינת יומן הפעילות');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { load(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [params]);
+
+  return (
+    <div className="activity-page" dir="rtl">
+      <header className="activity-header">
+        <div className="activity-title">
+          <Activity size={22} aria-hidden="true" />
+          <h1>יומן פעילות</h1>
+        </div>
+        <p className="activity-subtitle">
+          היסטוריית שינויים גלובלית על כל הרשומות שלך.
+        </p>
+      </header>
+
+      <section className="activity-filters" aria-label="סינון לפי סוג">
+        <div className="activity-chips" role="group" aria-label="סוג ישות">
+          {ENTITY_FILTERS.map((f) => (
+            <button
+              key={f.key || 'all'}
+              type="button"
+              className={`activity-chip ${entityType === f.key ? 'is-active' : ''}`}
+              onClick={() => setEntityType(f.key)}
+              aria-pressed={entityType === f.key}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+        <div className="activity-controls">
+          <label className="activity-limit">
+            <span>מספר שורות</span>
+            <select
+              value={limit}
+              onChange={(e) => setLimit(Number(e.target.value))}
+              aria-label="מספר שורות"
+            >
+              {LIMITS.map((n) => (
+                <option key={n} value={n}>{n}</option>
+              ))}
+            </select>
+          </label>
+          <button
+            type="button"
+            className="btn btn-ghost"
+            onClick={load}
+            aria-label="רענן"
+          >
+            <RefreshCw size={14} aria-hidden="true" />
+            <span>רענן</span>
+          </button>
+        </div>
+      </section>
+
+      <section className="activity-list" aria-busy={loading ? 'true' : 'false'}>
+        {loading && items.length === 0 ? (
+          <div className="activity-skel" aria-hidden>
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="activity-row activity-row-skel" />
+            ))}
+          </div>
+        ) : items.length === 0 ? (
+          <EmptyState
+            icon={<Activity size={40} />}
+            title="אין פעילות להצגה"
+            description="כאשר תבצע שינויים ברשומות הם יופיעו כאן."
+          />
+        ) : (
+          <ul className="activity-rows">
+            {items.map((item) => (
+              <li key={item.id} className="activity-row">
+                <div className="activity-row-head">
+                  <span className="activity-row-type">
+                    {displayText(ENTITY_LABEL[item.entityType] || item.entityType)}
+                  </span>
+                  <span className="activity-row-action">{displayText(item.action)}</span>
+                  <span className="activity-row-time">{displayDateTime(item.createdAt)}</span>
+                </div>
+                {item.summary && (
+                  <p className="activity-row-summary">{item.summary}</p>
+                )}
+                {item.actorName && (
+                  <span className="activity-row-actor">על ידי {item.actorName}</span>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}
+
+const ENTITY_LABEL = {
+  PROPERTY: 'נכס',
+  LEAD:     'לקוח',
+  DEAL:     'עסקה',
+  OWNER:    'בעל נכס',
+  REMINDER: 'תזכורת',
+  TAG:      'תגית',
+};

--- a/frontend/src/pages/ActivityLog.jsx
+++ b/frontend/src/pages/ActivityLog.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Activity, RefreshCw } from 'lucide-react';
 import api from '../lib/api';
 import { useToast } from '../lib/toast';
@@ -38,7 +38,7 @@ export default function ActivityLog() {
     return p;
   }, [entityType, limit]);
 
-  const load = async () => {
+  const load = useCallback(async () => {
     setLoading(true);
     try {
       const res = await api.listActivity(params);
@@ -48,9 +48,9 @@ export default function ActivityLog() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [params, toast]);
 
-  useEffect(() => { load(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [params]);
+  useEffect(() => { load(); }, [load]);
 
   return (
     <div className="activity-page" dir="rtl">

--- a/frontend/src/pages/CustomerDetail.css
+++ b/frontend/src/pages/CustomerDetail.css
@@ -328,3 +328,30 @@
     min-height: 48px;
   }
 }
+
+/* ── MLS parity — K1/K2/L1 subsections + embedded panel wrapper ─── */
+.cd-subsection {
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px dashed var(--border);
+}
+.cd-subsection-title {
+  font-family: var(--font-display);
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-secondary);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  margin: 0 0 12px;
+}
+/* Zero out chrome when we embed one of the shared panels (which ship
+   their own card chrome) inside a cd-section slot. */
+.cd-section-embedded {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  margin-bottom: 12px;
+}
+.cd-tags-section {
+  margin-bottom: 12px;
+}

--- a/frontend/src/pages/CustomerDetail.jsx
+++ b/frontend/src/pages/CustomerDetail.jsx
@@ -18,7 +18,19 @@ import {
 import api from '../lib/api';
 import WhatsAppIcon from '../components/WhatsAppIcon';
 import LeadMeetingDialog from '../components/LeadMeetingDialog';
+import TagPicker from '../components/TagPicker';
+import RemindersPanel from '../components/RemindersPanel';
+import MatchingList from '../components/MatchingList';
+import ActivityPanel from '../components/ActivityPanel';
+import LeadSearchProfilesEditor from '../components/LeadSearchProfilesEditor';
 import { NumberField, PhoneField, SelectField, Segmented } from '../components/SmartFields';
+import {
+  CUSTOMER_STATUS_LABELS,
+  QUICK_LEAD_STATUS_LABELS,
+  SERIOUSNESS_LABELS,
+  CUSTOMER_PURPOSE_LABELS,
+  labelsToOptions,
+} from '../lib/mlsLabels';
 import {
   inputPropsForName,
   inputPropsForEmail,
@@ -220,18 +232,41 @@ export default function CustomerDetail() {
         />
       )}
 
+      {/* H3 lead-side / A2 tags / D1 reminders / C3 matching / K4 profiles
+          — all additive. The existing edit form + derived timeline move
+          left; the new MLS-parity panels stack in the right column. */}
       <div className="cd-grid">
-        <CustomerEditForm
-          lead={lead}
-          onSaved={async (next) => {
-            setLead((cur) => ({ ...cur, ...next }));
-            toast.success('הפרטים נשמרו');
-            // Re-fetch to pick up any server-derived fields
-            try { await loadLead(); } catch { /* ignore */ }
-          }}
-          toast={toast}
-        />
-        <ActivityTimeline lead={lead} />
+        <div className="cd-form-col">
+          <section className="cd-section cd-tags-section" aria-label="תגי לקוח">
+            <h3 className="cd-section-title">תגים</h3>
+            <TagPicker entityType="LEAD" entityId={lead.id} />
+          </section>
+          <CustomerEditForm
+            lead={lead}
+            onSaved={async (next) => {
+              setLead((cur) => ({ ...cur, ...next }));
+              toast.success('הפרטים נשמרו');
+              // Re-fetch to pick up any server-derived fields
+              try { await loadLead(); } catch { /* ignore */ }
+            }}
+            toast={toast}
+          />
+          <div className="cd-section cd-section-embedded">
+            <LeadSearchProfilesEditor leadId={lead.id} />
+          </div>
+        </div>
+        <div className="cd-timeline-col">
+          <div className="cd-section cd-section-embedded">
+            <RemindersPanel leadId={lead.id} />
+          </div>
+          <div className="cd-section cd-section-embedded">
+            <MatchingList leadId={lead.id} />
+          </div>
+          <div className="cd-section cd-section-embedded">
+            <ActivityPanel entityType="Lead" entityId={lead.id} />
+          </div>
+          <ActivityTimeline lead={lead} />
+        </div>
       </div>
     </div>
   );
@@ -265,6 +300,30 @@ function CustomerEditForm({ lead, onSaved, toast }) {
     status: lead.status || 'WARM',
     source: lead.source || '',
     notes: lead.notes || '',
+
+    // K1 — contact / identity.
+    firstName: lead.firstName || '',
+    lastName:  lead.lastName  || '',
+    companyName: lead.companyName || '',
+    address: lead.address || '',
+    cityText: lead.cityText || '',
+    zip: lead.zip || '',
+    primaryPhone: lead.primaryPhone || '',
+    phone1: lead.phone1 || '',
+    phone2: lead.phone2 || '',
+    fax: lead.fax || '',
+    personalId: lead.personalId || '',
+    description: lead.description || '',
+
+    // K2 — admin.
+    customerStatus: lead.customerStatus || 'ACTIVE',
+    commissionPct: lead.commissionPct ?? null,
+    isPrivate: !!lead.isPrivate,
+    purposes: Array.isArray(lead.purposes) ? lead.purposes : [],
+    seriousnessOverride: lead.seriousnessOverride || 'NONE',
+
+    // L1 — quick lead status.
+    leadStatus: lead.leadStatus || 'NEW',
   });
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState(null);
@@ -298,6 +357,28 @@ function CustomerEditForm({ lead, onSaved, toast }) {
         status: form.status,
         source: form.source || null,
         notes: form.notes || null,
+
+        // K1 / K2 / L1 — mirror of NewLead submit shape.
+        firstName:   form.firstName?.trim()   || null,
+        lastName:    form.lastName?.trim()    || null,
+        companyName: form.companyName?.trim() || null,
+        address:     form.address?.trim()     || null,
+        cityText:    form.cityText?.trim()    || null,
+        zip:         form.zip?.trim()         || null,
+        primaryPhone: form.primaryPhone?.trim() || null,
+        phone1:      form.phone1?.trim()      || null,
+        phone2:      form.phone2?.trim()      || null,
+        fax:         form.fax?.trim()         || null,
+        personalId:  form.personalId?.trim()  || null,
+        description: form.description?.trim() || null,
+        customerStatus: form.customerStatus || 'ACTIVE',
+        commissionPct: form.commissionPct != null && form.commissionPct !== ''
+          ? Number(form.commissionPct)
+          : null,
+        isPrivate: !!form.isPrivate,
+        purposes: Array.isArray(form.purposes) ? form.purposes : [],
+        seriousnessOverride: form.seriousnessOverride || 'NONE',
+        leadStatus: form.leadStatus || 'NEW',
       };
       await api.updateLead(lead.id, body);
       onSaved(body);
@@ -422,6 +503,153 @@ function CustomerEditForm({ lead, onSaved, toast }) {
               value={form.notes}
               onChange={(e) => update('notes', e.target.value)}
             />
+          </div>
+        </div>
+
+        {/* K1 — contact identity block (additive). */}
+        <div className="cd-subsection">
+          <h4 className="cd-subsection-title">פרטים מורחבים</h4>
+          <div className="deal-form-grid">
+            <div className="form-group">
+              <label className="form-label" htmlFor="cd-k1-first">שם פרטי</label>
+              <input id="cd-k1-first" className="form-input" dir="auto" value={form.firstName}
+                onChange={(e) => update('firstName', e.target.value)} />
+            </div>
+            <div className="form-group">
+              <label className="form-label" htmlFor="cd-k1-last">שם משפחה</label>
+              <input id="cd-k1-last" className="form-input" dir="auto" value={form.lastName}
+                onChange={(e) => update('lastName', e.target.value)} />
+            </div>
+            <div className="form-group">
+              <label className="form-label" htmlFor="cd-k1-company">שם חברה</label>
+              <input id="cd-k1-company" className="form-input" dir="auto" value={form.companyName}
+                onChange={(e) => update('companyName', e.target.value)} />
+            </div>
+            <div className="form-group">
+              <label className="form-label" htmlFor="cd-k1-pid">ת.ז / ח.פ</label>
+              <input id="cd-k1-pid" className="form-input" dir="ltr" inputMode="numeric" value={form.personalId}
+                onChange={(e) => update('personalId', e.target.value)} />
+            </div>
+            <div className="form-group">
+              <label className="form-label" htmlFor="cd-k1-address">כתובת</label>
+              <input id="cd-k1-address" className="form-input" dir="auto" value={form.address}
+                onChange={(e) => update('address', e.target.value)} />
+            </div>
+            <div className="form-group">
+              <label className="form-label" htmlFor="cd-k1-citytext">עיר (חופשי)</label>
+              <input id="cd-k1-citytext" className="form-input" dir="auto" value={form.cityText}
+                onChange={(e) => update('cityText', e.target.value)} />
+            </div>
+            <div className="form-group">
+              <label className="form-label" htmlFor="cd-k1-zip">מיקוד</label>
+              <input id="cd-k1-zip" className="form-input" dir="ltr" inputMode="numeric" value={form.zip}
+                onChange={(e) => update('zip', e.target.value)} />
+            </div>
+            <div className="form-group">
+              <label className="form-label">טלפון עיקרי</label>
+              <PhoneField value={form.primaryPhone} onChange={(v) => update('primaryPhone', v)} />
+            </div>
+            <div className="form-group">
+              <label className="form-label">טלפון נוסף 1</label>
+              <PhoneField value={form.phone1} onChange={(v) => update('phone1', v)} />
+            </div>
+            <div className="form-group">
+              <label className="form-label">טלפון נוסף 2</label>
+              <PhoneField value={form.phone2} onChange={(v) => update('phone2', v)} />
+            </div>
+            <div className="form-group">
+              <label className="form-label" htmlFor="cd-k1-fax">פקס</label>
+              <input id="cd-k1-fax" className="form-input" dir="ltr" inputMode="tel" value={form.fax}
+                onChange={(e) => update('fax', e.target.value)} />
+            </div>
+            <div className="form-group form-group-wide">
+              <label className="form-label" htmlFor="cd-k1-desc">תיאור</label>
+              <input id="cd-k1-desc" className="form-input" dir="auto" value={form.description}
+                onChange={(e) => update('description', e.target.value)} />
+            </div>
+          </div>
+        </div>
+
+        {/* K2 + L1 — admin block. */}
+        <div className="cd-subsection">
+          <h4 className="cd-subsection-title">ניהול ולקוח</h4>
+          <div className="deal-form-grid">
+            <div className="form-group">
+              <label className="form-label" htmlFor="cd-k2-cs">סטטוס לקוח</label>
+              <SelectField
+                id="cd-k2-cs"
+                value={form.customerStatus}
+                onChange={(v) => update('customerStatus', v)}
+                options={labelsToOptions(CUSTOMER_STATUS_LABELS)}
+                aria-label="סטטוס לקוח"
+              />
+            </div>
+            <div className="form-group">
+              <label className="form-label" htmlFor="cd-k2-ls">סטטוס ליד</label>
+              <SelectField
+                id="cd-k2-ls"
+                value={form.leadStatus}
+                onChange={(v) => update('leadStatus', v)}
+                options={labelsToOptions(QUICK_LEAD_STATUS_LABELS)}
+                aria-label="סטטוס ליד"
+              />
+            </div>
+            <div className="form-group">
+              <label className="form-label">אחוז עמלה</label>
+              <NumberField
+                value={form.commissionPct}
+                onChange={(n) => update('commissionPct', n)}
+                unit="%"
+                min={0}
+                max={100}
+                placeholder="2"
+                aria-label="אחוז עמלה"
+              />
+            </div>
+            <div className="form-group">
+              <label className="form-label">רצינות</label>
+              <Segmented
+                value={form.seriousnessOverride}
+                onChange={(v) => update('seriousnessOverride', v)}
+                options={labelsToOptions(SERIOUSNESS_LABELS)}
+                ariaLabel="רצינות"
+              />
+            </div>
+            <div className="form-group form-group-wide">
+              <span className="form-label">מטרת הרכישה</span>
+              <div className="checkbox-grid" role="group" aria-label="מטרת הרכישה">
+                {Object.keys(CUSTOMER_PURPOSE_LABELS).map((val) => {
+                  const checked = form.purposes?.includes(val);
+                  return (
+                    <label key={val} className="checkbox-item">
+                      <input
+                        type="checkbox"
+                        checked={!!checked}
+                        onChange={(e) => {
+                          const set = new Set(form.purposes || []);
+                          if (e.target.checked) set.add(val);
+                          else set.delete(val);
+                          update('purposes', Array.from(set));
+                        }}
+                      />
+                      <span className="checkbox-custom" />
+                      {CUSTOMER_PURPOSE_LABELS[val]}
+                    </label>
+                  );
+                })}
+              </div>
+            </div>
+            <div className="form-group form-group-wide">
+              <label className="checkbox-item">
+                <input
+                  type="checkbox"
+                  checked={!!form.isPrivate}
+                  onChange={(e) => update('isPrivate', e.target.checked)}
+                />
+                <span className="checkbox-custom" />
+                לקוח פרטי (לא חשוף לשותפי משרד)
+              </label>
+            </div>
           </div>
         </div>
 

--- a/frontend/src/pages/Customers.css
+++ b/frontend/src/pages/Customers.css
@@ -1791,3 +1791,36 @@
 .cl-stale-pill:hover {
   background: color-mix(in srgb, var(--danger) 14%, var(--bg-card));
 }
+
+/* ─── Sprint 2 C2 + Sprint 7 B3/B4 additions ──────────────────────
+ * Header toolbar hosts three new controls (advanced filter, saved-
+ * search menu, favorites toggle). Count pill echoes the number of
+ * active filters on the trigger. Star aligns with the card name. */
+
+.cust-filter-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  margin-inline-start: 4px;
+  border-radius: 999px;
+  background: var(--gold, #d4a017);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.btn-ghost.is-active {
+  background: var(--gold-soft, color-mix(in srgb, var(--gold, #d4a017) 18%, transparent));
+  color: var(--gold-strong, #b8890f);
+}
+
+.cc-v2-name-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+

--- a/frontend/src/pages/Customers.jsx
+++ b/frontend/src/pages/Customers.jsx
@@ -27,6 +27,7 @@ import {
   Briefcase,
   CheckCircle2,
   User,
+  Star,
 } from 'lucide-react';
 import api from '../lib/api';
 import { useRouteScrollRestore } from '../hooks/useScrollRestore';
@@ -48,7 +49,39 @@ import { relativeTime, absoluteTime } from '../lib/time';
 import { relativeDate } from '../lib/relativeDate';
 import { waUrl, telUrl } from '../lib/waLink';
 import { leadMatchesProperty } from './Properties';
+import CustomerFiltersPanel from '../components/CustomerFiltersPanel';
+import SavedSearchMenu from '../components/SavedSearchMenu';
+import FavoriteStar from '../components/FavoriteStar';
 import './Customers.css';
+
+// Sprint 2 C2 — translate a UI filter object into the array-of-pairs
+// shape that api.listLeads → URLSearchParams understands for the
+// backend's repeated-key array params (`cities=A&cities=B`). Empty /
+// null values are dropped so we don't send `?minPrice=`.
+function filtersToQuery(filters) {
+  const pairs = [];
+  for (const [k, v] of Object.entries(filters || {})) {
+    if (v === null || v === undefined || v === '' || v === false) continue;
+    if (Array.isArray(v)) {
+      for (const item of v) if (item != null && item !== '') pairs.push([k, String(item)]);
+    } else if (v === true) {
+      pairs.push([k, '1']);
+    } else {
+      pairs.push([k, String(v)]);
+    }
+  }
+  return pairs;
+}
+
+// Count the top-level filter groups that are "active" — shown on the
+// filter trigger button as a summary chip. Arrays contribute 1 per
+// non-empty group; scalars / booleans contribute 1 when set.
+function countActiveFilters(filters) {
+  return Object.entries(filters || {}).filter(([, v]) => {
+    if (Array.isArray(v)) return v.length > 0;
+    return v !== null && v !== undefined && v !== '' && v !== false;
+  }).length;
+}
 
 function statusIcon(status) {
   switch (status) {
@@ -159,17 +192,35 @@ export default function Customers() {
   });
   const cardRefs = useRef({});
 
+  // Sprint 2 C2 + Sprint 7 B3/B4 — server-side Nadlan-parity filters,
+  // saved searches, and favorite toggle.
+  //
+  // `serverFilters` holds the object produced by <CustomerFiltersPanel>
+  // and is echoed into api.listLeads via filtersToQuery. Separate from
+  // the in-memory `lookingForFilter` / `interestFilter` / `statusFilter`
+  // chips above which filter the already-fetched array client-side.
+  const [serverFilters, setServerFilters] = useState({});
+  const [advancedFilterOpen, setAdvancedFilterOpen] = useState(false);
+  const [favoriteIds, setFavoriteIds] = useState(() => new Set());
+  const [onlyFavorites, setOnlyFavorites] = useState(false);
+
   const changeView = (v) => {
     setView(v);
     try { localStorage.setItem('estia-customers-view', v); } catch { /* ignore */ }
   };
 
-  const loadLeads = useCallback(async () => {
-    const r = await api.listLeads();
+  const loadLeads = useCallback(async (overrideFilters) => {
+    // Sprint 2 C2 — honor the advanced filter drawer by passing its
+    // object into api.listLeads. Array values become repeated keys
+    // (?cities=A&cities=B). When no filter is set we fall back to a
+    // bare call so URLSearchParams doesn't echo empty `?` noise.
+    const f = overrideFilters ?? serverFilters;
+    const params = Object.keys(f || {}).length ? filtersToQuery(f) : undefined;
+    const r = await api.listLeads(params);
     const next = r.items || [];
     setLeads(next);
     pageCache.set('customers', next);
-  }, []);
+  }, [serverFilters]);
 
   useEffect(() => {
     loadLeads().finally(() => setLoading(false));
@@ -181,6 +232,15 @@ export default function Customers() {
         pageCache.set('properties', next);
       })
       .catch(() => { /* ignore — pills simply hide */ });
+    // Sprint 7 B4 — seed the favorites set so each row's star reflects
+    // the current state without waiting for the first toggle. Empty
+    // set on failure is fine; each row just shows an empty star.
+    api.listFavorites('LEAD')
+      .then((r) => {
+        const ids = new Set((r?.items || []).map((f) => f.entityId));
+        setFavoriteIds(ids);
+      })
+      .catch(() => { /* ignore */ });
   }, [loadLeads]);
 
   // P3-D1: precompute match counts keyed by lead id
@@ -250,6 +310,8 @@ export default function Customers() {
         const days = (now - new Date(l.lastContact).getTime()) / DAY;
         if (days < inactiveFilter) return false;
       }
+      // Sprint 7 B4 — "רק מועדפים" toggle narrows to the starred set.
+      if (onlyFavorites && !favoriteIds.has(l.id)) return false;
       if (!debouncedSearch) return true;
       const s = debouncedSearch.toLowerCase();
       return (
@@ -258,7 +320,7 @@ export default function Customers() {
         l.phone?.includes(s)
       );
     });
-  }, [leads, lookingForFilter, interestFilter, statusFilter, inactiveFilter, debouncedSearch]);
+  }, [leads, lookingForFilter, interestFilter, statusFilter, inactiveFilter, debouncedSearch, onlyFavorites, favoriteIds]);
 
   const handleWhatsApp = (lead) => {
     primeContactBump(lead.id);
@@ -330,6 +392,48 @@ export default function Customers() {
 
   const handleStatusChange = (lead, newStatus) =>
     patchLead(lead.id, { status: newStatus }, { success: `סטטוס עודכן ל-${newStatus === 'HOT' ? 'חם' : newStatus === 'WARM' ? 'חמים' : 'קר'}` });
+
+  // Sprint 7 B4 — toggle a lead's favorite state. We update the local
+  // set optimistically before awaiting the API so the star flips as
+  // soon as the agent taps. A failure rolls back + surfaces a toast.
+  const handleToggleFavorite = async (leadId, nextActive) => {
+    setFavoriteIds((cur) => {
+      const copy = new Set(cur);
+      if (nextActive) copy.add(leadId);
+      else copy.delete(leadId);
+      return copy;
+    });
+    try {
+      if (nextActive) {
+        await api.addFavorite({ entityType: 'LEAD', entityId: leadId });
+      } else {
+        await api.removeFavorite('LEAD', leadId);
+      }
+    } catch (e) {
+      // Rollback
+      setFavoriteIds((cur) => {
+        const copy = new Set(cur);
+        if (nextActive) copy.delete(leadId);
+        else copy.add(leadId);
+        return copy;
+      });
+      toast.error(e?.message || 'שינוי המועדפים נכשל');
+    }
+  };
+
+  // Sprint 2 C2 — the advanced-filter drawer commits here. We store
+  // the new server filter set and immediately re-fetch.
+  const handleApplyServerFilters = async (nextFilters) => {
+    setServerFilters(nextFilters);
+    try {
+      await loadLeads(nextFilters);
+    } catch { /* toast handled by api layer */ }
+  };
+
+  const serverFilterCount = useMemo(
+    () => countActiveFilters(serverFilters),
+    [serverFilters],
+  );
 
   const confirmDeleteLead = async () => {
     if (!deleteTarget) return;
@@ -429,6 +533,42 @@ export default function Customers() {
           <p>{filtered.length} מתוך {leads.length} לקוחות</p>
         </div>
         <div className="page-header-actions">
+          {/* Sprint 2 C2 + Sprint 7 B3/B4 — advanced filter drawer,
+              saved-search menu, and "only favorites" toggle sit here
+              between the view switch and the primary "ליד חדש" CTA. */}
+          <button
+            type="button"
+            className={`btn btn-ghost btn-sm ${serverFilterCount > 0 ? 'is-active' : ''}`}
+            onClick={() => setAdvancedFilterOpen(true)}
+            aria-label={`סינון מתקדם${serverFilterCount > 0 ? ` (${serverFilterCount})` : ''}`}
+            title="סינון מתקדם"
+          >
+            <SlidersHorizontal size={14} aria-hidden="true" />
+            <span>סינון מתקדם</span>
+            {serverFilterCount > 0 && (
+              <span className="cust-filter-count" aria-hidden="true">{serverFilterCount}</span>
+            )}
+          </button>
+          <SavedSearchMenu
+            entityType="LEAD"
+            currentFilters={serverFilters}
+            onLoad={handleApplyServerFilters}
+          />
+          <button
+            type="button"
+            className={`btn btn-ghost btn-sm ${onlyFavorites ? 'is-active' : ''}`}
+            onClick={() => setOnlyFavorites((v) => !v)}
+            aria-pressed={onlyFavorites}
+            aria-label="רק מועדפים"
+            title="הצג רק מועדפים"
+          >
+            <Star
+              size={14}
+              aria-hidden="true"
+              fill={onlyFavorites ? 'currentColor' : 'none'}
+            />
+            <span>רק מועדפים</span>
+          </button>
           <div className="view-toggle" role="group" aria-label="תצוגה">
             <button
               className={`view-toggle-btn ${view === 'cards' ? 'active' : ''}`}
@@ -572,6 +712,8 @@ export default function Customers() {
           cardRefs={cardRefs}
           isMobile={isMobile}
           matchCountByLead={matchCountByLead}
+          favoriteIds={favoriteIds}
+          onToggleFavorite={handleToggleFavorite}
           onStatusChange={handleStatusChange}
           onEdit={setEditDialog}
           onDelete={setDeleteTarget}
@@ -640,6 +782,13 @@ export default function Customers() {
                         <div className="ccm-mid">
                           <div className="ccm-name-row">
                             <strong className="ccm-name">{lead.name}</strong>
+                            {/* Sprint 7 B4 — favorite toggle; stop
+                                propagation is handled inside FavoriteStar. */}
+                            <FavoriteStar
+                              active={favoriteIds.has(lead.id)}
+                              onToggle={(next) => handleToggleFavorite(lead.id, next)}
+                              className="fav-star-sm"
+                            />
                             {/* P2-M17: status reason pill inline next to name */}
                             <span className={`ccm-reason-pill ${reasonStatusClass}`} title={lead.statusExplanation || ''}>
                               <span className="ccm-reason-emoji" aria-hidden="true">{reason.emoji}</span>
@@ -881,9 +1030,16 @@ export default function Customers() {
                 <div className="cc-v2-left">
                   <div className="customer-avatar">{lead.name.charAt(0)}</div>
                   <div className="cc-v2-name">
-                    <Link to={`/customers/${lead.id}`} className="customer-name-link">
-                      <strong>{lead.name}</strong>
-                    </Link>
+                    <div className="cc-v2-name-row">
+                      <Link to={`/customers/${lead.id}`} className="customer-name-link">
+                        <strong>{lead.name}</strong>
+                      </Link>
+                      {/* Sprint 7 B4 — favorite toggle inline with the name. */}
+                      <FavoriteStar
+                        active={favoriteIds.has(lead.id)}
+                        onToggle={(next) => handleToggleFavorite(lead.id, next)}
+                      />
+                    </div>
                     <StatusPicker lead={lead} onChange={handleStatusChange} />
                   </div>
                 </div>
@@ -1118,6 +1274,16 @@ export default function Customers() {
           onClose={() => setFilterSheetOpen(false)}
         />
       )}
+
+      {/* Sprint 2 C2 — Nadlan-parity advanced filter drawer. Opens
+          from the "סינון מתקדם" button in the header; apply re-fetches
+          /api/leads with the selected filters. */}
+      <CustomerFiltersPanel
+        open={advancedFilterOpen}
+        filters={serverFilters}
+        onApply={handleApplyServerFilters}
+        onClose={() => setAdvancedFilterOpen(false)}
+      />
     </div>
     </PullRefresh>
   );
@@ -1131,6 +1297,8 @@ function CustomerList({
   cardRefs,
   isMobile,
   matchCountByLead = {},
+  favoriteIds,
+  onToggleFavorite,
   onStatusChange,
   onEdit,
   onDelete,
@@ -1243,6 +1411,17 @@ function CustomerList({
                   title={`פתח כרטיס לקוח של ${lead.name}`}
                 >
                   <td className="cl-td cl-td-name">
+                    {/* Sprint 7 B4 — star sits on the row so agents can
+                        flag a lead without opening the detail page. */}
+                    {onToggleFavorite && (
+                      <span onClick={(e) => e.stopPropagation()}>
+                        <FavoriteStar
+                          active={favoriteIds?.has(lead.id) || false}
+                          onToggle={(next) => onToggleFavorite(lead.id, next)}
+                          className="fav-star-sm"
+                        />
+                      </span>
+                    )}
                     <span className="cl-avatar">{lead.name.charAt(0)}</span>
                     <span className="cl-name-text">
                       <strong>{lead.name}</strong>
@@ -1347,6 +1526,13 @@ function CustomerList({
             className={`customer-list-row ${highlightId === lead.id ? 'highlight' : ''}`}
           >
             <span className="cl-name">
+              {onToggleFavorite && (
+                <FavoriteStar
+                  active={favoriteIds?.has(lead.id) || false}
+                  onToggle={(next) => onToggleFavorite(lead.id, next)}
+                  className="fav-star-sm"
+                />
+              )}
               <span className="cl-avatar">{lead.name.charAt(0)}</span>
               <span className="cl-name-text">
                 <strong>{lead.name}</strong>

--- a/frontend/src/pages/Dashboard.css
+++ b/frontend/src/pages/Dashboard.css
@@ -152,6 +152,33 @@
   margin-right: 4px;
 }
 
+/* B2 — period switcher above the KPI row ("שנה תקופה: week / month /
+   quarter"). Sits flush with the stat rail so the whole counters
+   section reads as one block. */
+.kpi-period-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.kpi-period-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+/* Stat-value row — the number sits next to its DeltaBadge pill. Uses
+   inline-flex so the pill wraps onto a second line on very narrow
+   stat cards rather than pushing the label sideways. */
+.stat-value-row {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
+  line-height: 1;
+}
+
 /* Stats — clickable cards */
 .stats-grid {
   display: grid;

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -23,12 +23,24 @@ import api from '../lib/api';
 import { useAuth } from '../lib/auth';
 import ShareCatalogDialog from '../components/ShareCatalogDialog';
 import PullRefresh from '../components/PullRefresh';
+import DeltaBadge from '../components/DeltaBadge';
+import { Segmented } from '../components/SmartFields';
 import { relativeDate } from '../lib/relativeDate';
 import { shareSheet } from '../native/share';
 import { useViewportMobile, useDelayedFlag } from '../hooks/mobile';
+import useDashboardDeltas from '../hooks/useDashboardDeltas';
 import { pageCache } from '../lib/pageCache';
 import haptics from '../lib/haptics';
 import './Dashboard.css';
+
+// Maps a period value to the Hebrew label shown inside DeltaBadge
+// ("+3 השבוע"). Kept outside the component so it's a stable reference.
+const PERIOD_LABEL = { week: 'השבוע', month: 'החודש', quarter: 'הרבעון' };
+const PERIOD_OPTIONS = [
+  { value: 'week', label: 'שבוע' },
+  { value: 'month', label: 'חודש' },
+  { value: 'quarter', label: 'רבעון' },
+];
 
 function formatPrice(price) {
   if (!price) return '₪0';
@@ -42,6 +54,11 @@ export default function Dashboard() {
   const _cached = pageCache.get('dashboard');
   const [data, setData] = useState(_cached || null);
   const [loading, setLoading] = useState(!_cached);
+  // B2 — rolling-delta window. Default "week" matches Nadlan One's
+  // out-of-the-box dashboard. All three windows are fetched once on
+  // mount (see useDashboardDeltas) so switching is instant.
+  const [period, setPeriod] = useState('week');
+  const deltas = useDashboardDeltas(period);
 
   const load = async () => {
     try {
@@ -145,6 +162,7 @@ export default function Dashboard() {
       color: 'var(--gold)',
       bg: 'var(--gold-glow)',
       to: '/properties?assetClass=residential',
+      deltaKey: 'properties',
     },
     {
       icon: Store,
@@ -154,6 +172,7 @@ export default function Dashboard() {
       color: 'var(--warning)',
       bg: 'var(--warning-bg)',
       to: '/properties?assetClass=commercial',
+      deltaKey: 'properties',
     },
     {
       icon: Target,
@@ -163,6 +182,7 @@ export default function Dashboard() {
       color: 'var(--danger)',
       bg: 'var(--danger-bg)',
       to: '/customers?filter=hot',
+      deltaKey: 'customers',
     },
     {
       icon: Handshake,
@@ -172,6 +192,7 @@ export default function Dashboard() {
       color: 'var(--success)',
       bg: 'var(--success-bg)',
       to: '/deals',
+      deltaKey: 'deals',
     },
     {
       icon: TrendingUp,
@@ -181,6 +202,9 @@ export default function Dashboard() {
       color: 'var(--info)',
       bg: 'var(--info-bg)',
       to: '/deals?tab=signed',
+      // Commission-total doesn't map cleanly to a count delta, so we
+      // intentionally don't show a pill here.
+      deltaKey: null,
     },
     {
       icon: UserCircle,
@@ -190,6 +214,8 @@ export default function Dashboard() {
       color: 'var(--gold)',
       bg: 'var(--gold-glow)',
       to: '/owners',
+      // No report endpoint for owners deltas yet.
+      deltaKey: null,
     },
   ];
 
@@ -211,7 +237,22 @@ export default function Dashboard() {
 
         <TodayStrip leads={leads} properties={properties} />
 
-        <KpiScroller stats={stats} refreshing={isRefreshing} />
+        <div className="kpi-period-row">
+          <span className="kpi-period-label">שנה תקופה</span>
+          <Segmented
+            value={period}
+            onChange={setPeriod}
+            options={PERIOD_OPTIONS}
+            ariaLabel="בחר תקופה להשוואה"
+          />
+        </div>
+
+        <KpiScroller
+          stats={stats}
+          refreshing={isRefreshing}
+          deltaBucket={deltas[period]}
+          periodLabel={PERIOD_LABEL[period]}
+        />
 
         {staleLeads.length > 0 && (
         <div className="dash-signals animate-in animate-in-delay-2">
@@ -378,7 +419,7 @@ export default function Dashboard() {
   );
 }
 
-function KpiScroller({ stats, refreshing = false }) {
+function KpiScroller({ stats, refreshing = false, deltaBucket = null, periodLabel = 'השבוע' }) {
   const trackRef = useRef(null);
   const [activeIdx, setActiveIdx] = useState(0);
 
@@ -405,23 +446,38 @@ function KpiScroller({ stats, refreshing = false }) {
   return (
     <>
       <div className="stats-grid" ref={trackRef}>
-        {stats.map((stat, i) => (
-          <Link
-            key={stat.label}
-            to={stat.to}
-            className={`stat-card animate-in animate-in-delay-${Math.min(i + 1, 5)}`}
-            onClick={() => haptics.tap()}
-          >
-            <div className="stat-icon" style={{ background: stat.bg, color: stat.color }}>
-              <stat.icon size={22} />
-            </div>
-            <div className="stat-info">
-              <span className={`stat-value ${refreshing ? 'stat-value-refreshing' : ''}`}>{stat.value}</span>
-              <span className="stat-label">{stat.label}</span>
-              <span className="stat-sub">{stat.sub}</span>
-            </div>
-          </Link>
-        ))}
+        {stats.map((stat, i) => {
+          // Per-KPI delta — null means either the bucket failed to load
+          // or this stat doesn't map to a report endpoint (owners,
+          // commission total). In both cases we just skip the pill so
+          // the tile still shows its total.
+          const deltaValue = stat.deltaKey && deltaBucket
+            ? deltaBucket[stat.deltaKey]
+            : null;
+          const showDelta = stat.deltaKey && Number.isFinite(Number(deltaValue));
+          return (
+            <Link
+              key={stat.label}
+              to={stat.to}
+              className={`stat-card animate-in animate-in-delay-${Math.min(i + 1, 5)}`}
+              onClick={() => haptics.tap()}
+            >
+              <div className="stat-icon" style={{ background: stat.bg, color: stat.color }}>
+                <stat.icon size={22} />
+              </div>
+              <div className="stat-info">
+                <span className="stat-value-row">
+                  <span className={`stat-value ${refreshing ? 'stat-value-refreshing' : ''}`}>{stat.value}</span>
+                  {showDelta && (
+                    <DeltaBadge value={Number(deltaValue)} label={periodLabel} />
+                  )}
+                </span>
+                <span className="stat-label">{stat.label}</span>
+                <span className="stat-sub">{stat.sub}</span>
+              </div>
+            </Link>
+          );
+        })}
       </div>
       <div className="stats-dots" aria-hidden="true">
         {stats.map((_, i) => (

--- a/frontend/src/pages/NewLead.jsx
+++ b/frontend/src/pages/NewLead.jsx
@@ -14,12 +14,23 @@ import {
   inputPropsForCity,
   inputPropsForAddress,
 } from '../lib/inputProps';
-import { PhoneField, PriceRange, Segmented, SelectField } from '../components/SmartFields';
+import { NumberField, PhoneField, PriceRange, Segmented, SelectField } from '../components/SmartFields';
+import {
+  CUSTOMER_STATUS_LABELS,
+  QUICK_LEAD_STATUS_LABELS,
+  SERIOUSNESS_LABELS,
+  CUSTOMER_PURPOSE_LABELS,
+  labelsToOptions,
+} from '../lib/mlsLabels';
 import './Forms.css';
 
 const DRAFT_KEY = 'estia-draft:new-lead';
 
+// K2 — purposes is a multi-select. Order matches Nadlan One's UI.
+const PURPOSE_OPTIONS = Object.keys(CUSTOMER_PURPOSE_LABELS);
+
 const INITIAL_FORM = {
+  // Legacy — kept so the existing save path still works.
   name: '',
   phone: '',
   interestType: 'פרטי',
@@ -41,6 +52,30 @@ const INITIAL_FORM = {
   acRequired: false,
   storageRequired: false,
   notes: '',
+
+  // K1 — contact / identity block (additive, all optional).
+  firstName: '',
+  lastName: '',
+  companyName: '',
+  address: '',
+  cityText: '',
+  zip: '',
+  primaryPhone: '',
+  phone1: '',
+  phone2: '',
+  fax: '',
+  personalId: '',
+  description: '',
+
+  // K2 — admin block.
+  customerStatus: 'ACTIVE',
+  commissionPct: null,
+  isPrivate: false,
+  purposes: [],
+  seriousnessOverride: 'NONE',
+
+  // L1 — quick lead status.
+  leadStatus: 'NEW',
 };
 
 export default function NewLead() {
@@ -163,6 +198,33 @@ export default function NewLead() {
         acRequired: !!form.acRequired,
         storageRequired: !!form.storageRequired,
         notes: form.notes || null,
+
+        // K1 — contact / identity (only send non-empty so the server
+        // doesn't overwrite existing rows with "" on edit paths).
+        firstName:   form.firstName?.trim()   || null,
+        lastName:    form.lastName?.trim()    || null,
+        companyName: form.companyName?.trim() || null,
+        address:     form.address?.trim()     || null,
+        cityText:    form.cityText?.trim()    || null,
+        zip:         form.zip?.trim()         || null,
+        primaryPhone: form.primaryPhone?.trim() || null,
+        phone1:      form.phone1?.trim()      || null,
+        phone2:      form.phone2?.trim()      || null,
+        fax:         form.fax?.trim()         || null,
+        personalId:  form.personalId?.trim()  || null,
+        description: form.description?.trim() || null,
+
+        // K2 — admin block.
+        customerStatus: form.customerStatus || 'ACTIVE',
+        commissionPct: form.commissionPct != null && form.commissionPct !== ''
+          ? Number(form.commissionPct)
+          : null,
+        isPrivate: !!form.isPrivate,
+        purposes: Array.isArray(form.purposes) ? form.purposes : [],
+        seriousnessOverride: form.seriousnessOverride || 'NONE',
+
+        // L1 — quick lead status.
+        leadStatus: form.leadStatus || 'NEW',
       };
       const res = await api.createLead(body);
       savedRef.current = true;
@@ -452,6 +514,224 @@ export default function NewLead() {
               מחסן
             </label>
           </div>
+        </div>
+
+        <div className="form-section">
+          {/* K1 — contact / identity block. Optional: agents who only
+              have a phone number can leave the whole section blank. */}
+          <h3 className="form-section-title">פרטים מורחבים</h3>
+          <div className="form-row">
+            <div className="form-group">
+              <label className="form-label" htmlFor="k1-first">שם פרטי</label>
+              <input
+                id="k1-first"
+                className="form-input"
+                dir="auto"
+                autoCapitalize="words"
+                enterKeyHint="next"
+                value={form.firstName}
+                onChange={(e) => update('firstName', e.target.value)}
+              />
+            </div>
+            <div className="form-group">
+              <label className="form-label" htmlFor="k1-last">שם משפחה</label>
+              <input
+                id="k1-last"
+                className="form-input"
+                dir="auto"
+                autoCapitalize="words"
+                enterKeyHint="next"
+                value={form.lastName}
+                onChange={(e) => update('lastName', e.target.value)}
+              />
+            </div>
+          </div>
+          <div className="form-row">
+            <div className="form-group">
+              <label className="form-label" htmlFor="k1-company">שם חברה</label>
+              <input
+                id="k1-company"
+                className="form-input"
+                dir="auto"
+                enterKeyHint="next"
+                value={form.companyName}
+                onChange={(e) => update('companyName', e.target.value)}
+              />
+            </div>
+            <div className="form-group">
+              <label className="form-label" htmlFor="k1-pid">ת.ז / ח.פ</label>
+              <input
+                id="k1-pid"
+                className="form-input"
+                dir="ltr"
+                inputMode="numeric"
+                value={form.personalId}
+                onChange={(e) => update('personalId', e.target.value)}
+              />
+            </div>
+          </div>
+          <div className="form-row">
+            <div className="form-group">
+              <label className="form-label" htmlFor="k1-address">כתובת</label>
+              <input
+                id="k1-address"
+                className="form-input"
+                dir="auto"
+                enterKeyHint="next"
+                value={form.address}
+                onChange={(e) => update('address', e.target.value)}
+              />
+            </div>
+            <div className="form-group">
+              <label className="form-label" htmlFor="k1-city">עיר (חופשי)</label>
+              <input
+                id="k1-city"
+                className="form-input"
+                dir="auto"
+                enterKeyHint="next"
+                value={form.cityText}
+                onChange={(e) => update('cityText', e.target.value)}
+              />
+            </div>
+          </div>
+          <div className="form-row">
+            <div className="form-group">
+              <label className="form-label" htmlFor="k1-zip">מיקוד</label>
+              <input
+                id="k1-zip"
+                className="form-input"
+                dir="ltr"
+                inputMode="numeric"
+                value={form.zip}
+                onChange={(e) => update('zip', e.target.value)}
+              />
+            </div>
+            <div className="form-group">
+              <label className="form-label">טלפון עיקרי</label>
+              <PhoneField
+                value={form.primaryPhone}
+                onChange={(v) => update('primaryPhone', v)}
+              />
+            </div>
+          </div>
+          <div className="form-row">
+            <div className="form-group">
+              <label className="form-label">טלפון נוסף 1</label>
+              <PhoneField value={form.phone1} onChange={(v) => update('phone1', v)} />
+            </div>
+            <div className="form-group">
+              <label className="form-label">טלפון נוסף 2</label>
+              <PhoneField value={form.phone2} onChange={(v) => update('phone2', v)} />
+            </div>
+          </div>
+          <div className="form-row">
+            <div className="form-group">
+              <label className="form-label" htmlFor="k1-fax">פקס</label>
+              <input
+                id="k1-fax"
+                className="form-input"
+                dir="ltr"
+                inputMode="tel"
+                value={form.fax}
+                onChange={(e) => update('fax', e.target.value)}
+              />
+            </div>
+            <div className="form-group">
+              <label className="form-label" htmlFor="k1-desc">תיאור</label>
+              <input
+                id="k1-desc"
+                className="form-input"
+                dir="auto"
+                enterKeyHint="next"
+                value={form.description}
+                onChange={(e) => update('description', e.target.value)}
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="form-section">
+          {/* K2 + L1 — admin block. Lives in its own section so agents
+              can skip it entirely on quick-capture. */}
+          <h3 className="form-section-title">ניהול ולקוח</h3>
+          <div className="form-row">
+            <div className="form-group">
+              <label className="form-label" htmlFor="k2-cs">סטטוס לקוח</label>
+              <SelectField
+                value={form.customerStatus}
+                onChange={(v) => update('customerStatus', v)}
+                options={labelsToOptions(CUSTOMER_STATUS_LABELS)}
+                aria-label="סטטוס לקוח"
+                id="k2-cs"
+              />
+            </div>
+            <div className="form-group">
+              <label className="form-label" htmlFor="k2-ls">סטטוס ליד</label>
+              <SelectField
+                value={form.leadStatus}
+                onChange={(v) => update('leadStatus', v)}
+                options={labelsToOptions(QUICK_LEAD_STATUS_LABELS)}
+                aria-label="סטטוס ליד"
+                id="k2-ls"
+              />
+            </div>
+          </div>
+          <div className="form-row">
+            <div className="form-group">
+              <label className="form-label">אחוז עמלה</label>
+              <NumberField
+                value={form.commissionPct}
+                onChange={(n) => update('commissionPct', n)}
+                unit="%"
+                min={0}
+                max={100}
+                placeholder="2"
+                aria-label="אחוז עמלה"
+              />
+            </div>
+            <div className="form-group">
+              <label className="form-label">רצינות</label>
+              <Segmented
+                value={form.seriousnessOverride}
+                onChange={(v) => update('seriousnessOverride', v)}
+                options={labelsToOptions(SERIOUSNESS_LABELS)}
+                ariaLabel="רצינות"
+              />
+            </div>
+          </div>
+          <div className="form-group" style={{ marginBottom: 12 }}>
+            <span className="form-label">מטרת הרכישה</span>
+            <div className="checkbox-grid" role="group" aria-label="מטרת הרכישה">
+              {PURPOSE_OPTIONS.map((val) => {
+                const checked = form.purposes?.includes(val);
+                return (
+                  <label key={val} className="checkbox-item">
+                    <input
+                      type="checkbox"
+                      checked={!!checked}
+                      onChange={(e) => {
+                        const set = new Set(form.purposes || []);
+                        if (e.target.checked) set.add(val);
+                        else set.delete(val);
+                        update('purposes', Array.from(set));
+                      }}
+                    />
+                    <span className="checkbox-custom" />
+                    {CUSTOMER_PURPOSE_LABELS[val]}
+                  </label>
+                );
+              })}
+            </div>
+          </div>
+          <label className="checkbox-item" style={{ marginTop: 4 }}>
+            <input
+              type="checkbox"
+              checked={!!form.isPrivate}
+              onChange={(e) => update('isPrivate', e.target.checked)}
+            />
+            <span className="checkbox-custom" />
+            לקוח פרטי (לא חשוף לשותפי משרד)
+          </label>
         </div>
 
         <div className="form-section">

--- a/frontend/src/pages/NewProperty.css
+++ b/frontend/src/pages/NewProperty.css
@@ -434,3 +434,13 @@
 .np-agreement-link:hover { text-decoration: underline; }
 .np-agreement-actions { display: inline-flex; gap: 6px; }
 
+
+/* J4–J7 fieldsets. Reuse the form's checkbox-grid for heating-types. */
+.np-heating {
+  margin: 0;
+  padding: 0;
+  border: none;
+}
+.np-heating > legend {
+  margin-block-end: 8px;
+}

--- a/frontend/src/pages/NewProperty.jsx
+++ b/frontend/src/pages/NewProperty.jsx
@@ -31,9 +31,18 @@ import {
 } from '../lib/inputProps';
 import { NumberField, PhoneField, SelectField, Segmented } from '../components/SmartFields';
 import PageTour from '../components/PageTour';
+import PropertyPipelineBlock from '../components/PropertyPipelineBlock';
+import {
+  PROPERTY_CONDITION_LABELS,
+  HEATING_TYPE_LABELS,
+  labelsToOptions,
+} from '../lib/mlsLabels';
 import { getPositionDetailed } from '../native/geolocation';
 import './Forms.css';
 import './NewProperty.css';
+
+const CONDITION_OPTIONS = labelsToOptions(PROPERTY_CONDITION_LABELS);
+const HEATING_TYPES = Object.keys(HEATING_TYPE_LABELS);
 
 const DRAFT_KEY = 'estia-draft:new-property';
 
@@ -131,6 +140,32 @@ const INITIAL_FORM = {
   meetingRoom: false,
   workstations: null,
   lobbySecurity: false,
+
+  // Sprint 3 J4–J7 — Nadlan parity extras.
+  condition: '',
+  heatingTypes: [],
+  halfRooms: null,
+  masterBedroom: false,
+  bathrooms: null,
+  toilets: null,
+  furnished: false,
+  petFriendly: false,
+  doormenService: false,
+  gym: false,
+  pool: false,
+  gatedCommunity: false,
+  accessibility: false,
+  utilityRoom: false,
+  listingSource: '',
+
+  // Sprint 1 J9 — broker-side pipeline fields. The PropertyPipelineBlock
+  // reads/writes these directly from the form state.
+  stage: 'WATCHING',
+  agentCommissionPct: null,
+  primaryAgentId: null,
+  exclusivityExpire: '',
+  sellerSeriousness: 'NONE',
+  brokerNotes: '',
 };
 
 /**
@@ -284,6 +319,31 @@ export default function NewProperty() {
           meetingRoom: !!p.meetingRoom,
           workstations: p.workstations ?? null,
           lobbySecurity: !!p.lobbySecurity,
+          // J4–J7 extras
+          condition: p.condition || '',
+          heatingTypes: Array.isArray(p.heatingTypes) ? p.heatingTypes : [],
+          halfRooms: p.halfRooms ?? null,
+          masterBedroom: !!p.masterBedroom,
+          bathrooms: p.bathrooms ?? null,
+          toilets: p.toilets ?? null,
+          furnished: !!p.furnished,
+          petFriendly: !!p.petFriendly,
+          doormenService: !!p.doormenService,
+          gym: !!p.gym,
+          pool: !!p.pool,
+          gatedCommunity: !!p.gatedCommunity,
+          accessibility: !!p.accessibility,
+          utilityRoom: !!p.utilityRoom,
+          listingSource: p.listingSource || '',
+          // J9 pipeline
+          stage: p.stage || 'WATCHING',
+          agentCommissionPct: p.agentCommissionPct ?? null,
+          primaryAgentId: p.primaryAgentId || null,
+          exclusivityExpire: p.exclusivityExpire
+            ? String(p.exclusivityExpire).slice(0, 10)
+            : '',
+          sellerSeriousness: p.sellerSeriousness || 'NONE',
+          brokerNotes: p.brokerNotes || '',
         });
         setExistingMeta({
           street: p.street,
@@ -485,6 +545,33 @@ export default function NewProperty() {
     meetingRoom: !!form.meetingRoom,
     workstations: numOrNull(form.workstations),
     lobbySecurity: !!form.lobbySecurity,
+    // J4–J7 Nadlan parity extras
+    condition: form.condition || null,
+    heatingTypes: Array.isArray(form.heatingTypes) ? form.heatingTypes : [],
+    halfRooms: numOrNull(form.halfRooms),
+    masterBedroom: !!form.masterBedroom,
+    bathrooms: numOrNull(form.bathrooms),
+    toilets: numOrNull(form.toilets),
+    furnished: !!form.furnished,
+    petFriendly: !!form.petFriendly,
+    doormenService: !!form.doormenService,
+    gym: !!form.gym,
+    pool: !!form.pool,
+    gatedCommunity: !!form.gatedCommunity,
+    accessibility: !!form.accessibility,
+    utilityRoom: !!form.utilityRoom,
+    listingSource: form.listingSource || null,
+    // J9 broker pipeline
+    stage: form.stage || 'WATCHING',
+    agentCommissionPct: form.agentCommissionPct == null || form.agentCommissionPct === ''
+      ? null
+      : Number(form.agentCommissionPct),
+    primaryAgentId: form.primaryAgentId || null,
+    exclusivityExpire: form.exclusivityExpire
+      ? new Date(form.exclusivityExpire).toISOString()
+      : null,
+    sellerSeriousness: form.sellerSeriousness || 'NONE',
+    brokerNotes: form.brokerNotes || '',
   });
   const buildFullEditBody = () => ({ ...buildStep1Body(), ...buildStep2Body() });
 
@@ -1278,6 +1365,135 @@ export default function NewProperty() {
               </div>
             </div>
           )}
+
+          {/* ── J4–J7 — Nadlan parity extras ───────────────────────── */}
+          <div className="form-section">
+            <h3 className="form-section-title">פרטים נוספים (J4–J7)</h3>
+            <div className="form-row form-row-3">
+              <div className="form-group">
+                <label className="form-label" htmlFor="np-condition">מצב נכס</label>
+                <SelectField
+                  id="np-condition"
+                  value={form.condition}
+                  onChange={(v) => update('condition', v)}
+                  options={CONDITION_OPTIONS}
+                  placeholder="בחר…"
+                  aria-label="מצב הנכס"
+                />
+              </div>
+              <div className="form-group">
+                <label className="form-label" htmlFor="np-half-rooms">חצאי חדרים</label>
+                <NumberField
+                  id="np-half-rooms"
+                  value={form.halfRooms}
+                  onChange={(v) => update('halfRooms', v)}
+                  min={0}
+                  max={10}
+                  placeholder="0"
+                />
+              </div>
+              <div className="form-group">
+                <label className="form-label" htmlFor="np-listing-source">מקור הנכס</label>
+                <input
+                  id="np-listing-source"
+                  type="text"
+                  className="form-input"
+                  value={form.listingSource}
+                  onChange={(e) => update('listingSource', e.target.value)}
+                  placeholder="yad2 / referral / onmap"
+                />
+              </div>
+            </div>
+            <div className="form-row form-row-3">
+              <div className="form-group">
+                <label className="form-label" htmlFor="np-bathrooms">חדרי אמבטיה</label>
+                <NumberField
+                  id="np-bathrooms"
+                  value={form.bathrooms}
+                  onChange={(v) => update('bathrooms', v)}
+                  min={0}
+                  max={10}
+                  placeholder="1"
+                />
+              </div>
+              <div className="form-group">
+                <label className="form-label" htmlFor="np-toilets">שירותים</label>
+                <NumberField
+                  id="np-toilets"
+                  value={form.toilets}
+                  onChange={(v) => update('toilets', v)}
+                  min={0}
+                  max={10}
+                  placeholder="1"
+                />
+              </div>
+            </div>
+            <fieldset className="np-heating">
+              <legend className="form-label">חימום</legend>
+              <div className="checkbox-grid">
+                {HEATING_TYPES.map((key) => {
+                  const label = HEATING_TYPE_LABELS[key];
+                  const selected = form.heatingTypes.includes(key);
+                  return (
+                    <label key={key} className="checkbox-item">
+                      <input
+                        type="checkbox"
+                        checked={selected}
+                        onChange={(e) => {
+                          const next = e.target.checked
+                            ? [...form.heatingTypes, key]
+                            : form.heatingTypes.filter((k) => k !== key);
+                          update('heatingTypes', next);
+                        }}
+                      />
+                      <span className="checkbox-custom" />
+                      {label}
+                    </label>
+                  );
+                })}
+              </div>
+            </fieldset>
+            <div className="checkbox-grid">
+              {[
+                { key: 'masterBedroom',   label: 'חדר הורים' },
+                { key: 'utilityRoom',     label: 'חדר שירות' },
+                { key: 'furnished',       label: 'מרוהטת' },
+                { key: 'petFriendly',     label: 'ידידותי לחיות מחמד' },
+                { key: 'doormenService',  label: 'שירות קונסיירז׳' },
+                { key: 'gym',             label: 'חדר כושר בבניין' },
+                { key: 'pool',            label: 'בריכת שחייה' },
+                { key: 'gatedCommunity',  label: 'קהילה סגורה' },
+                { key: 'accessibility',   label: 'נגישות לנכי' },
+              ].map(({ key, label }) => (
+                <label key={key} className="checkbox-item">
+                  <input
+                    type="checkbox"
+                    checked={!!form[key]}
+                    onChange={(e) => update(key, e.target.checked)}
+                  />
+                  <span className="checkbox-custom" />
+                  {label}
+                </label>
+              ))}
+            </div>
+          </div>
+
+          {/* ── J9 — צנרת תיווך ───────────────────────────────────── */}
+          <div className="form-section">
+            <h3 className="form-section-title">צנרת תיווך</h3>
+            <PropertyPipelineBlock
+              form={{
+                stage: form.stage,
+                agentCommissionPct: form.agentCommissionPct,
+                primaryAgentId: form.primaryAgentId,
+                exclusivityExpire: form.exclusivityExpire,
+                sellerSeriousness: form.sellerSeriousness,
+                brokerNotes: form.brokerNotes,
+              }}
+              onChange={update}
+              toast={toast}
+            />
+          </div>
 
           {/* ── מחסן מפורט ─────────────────────────────────────────── */}
           {form.storage && (

--- a/frontend/src/pages/Office.css
+++ b/frontend/src/pages/Office.css
@@ -1,0 +1,152 @@
+.office-page {
+  max-width: 860px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.office-header { display: flex; flex-direction: column; gap: 4px; }
+
+.office-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.office-title h1 {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.office-subtitle {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+.office-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 16px;
+}
+
+.office-card-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 12px;
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.office-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.office-form-row {
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: flex-end;
+}
+
+.office-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 200px;
+}
+
+.office-field-grow { flex: 1; }
+
+.office-field span {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.office-field input {
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg-card);
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: 14px;
+}
+
+.office-field input:focus {
+  outline: 2px solid var(--gold, #c9a14a);
+  outline-offset: 1px;
+}
+
+.office-members {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.office-member {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--bg-elevated, transparent);
+}
+
+.office-member-body { flex: 1; min-width: 0; }
+
+.office-member-name {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 700;
+  color: var(--text-primary);
+  font-size: 14px;
+}
+
+.office-member-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--gold, #c9a14a);
+  color: var(--bg-primary, #fff);
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.office-member-email {
+  font-size: 12px;
+  color: var(--text-secondary);
+  direction: ltr;
+  text-align: start;
+}
+
+.office-remove {
+  color: var(--danger, #c0392b);
+}
+
+.office-skel {
+  height: 200px;
+  background: linear-gradient(90deg, var(--bg-elevated, #eee), var(--bg-card), var(--bg-elevated, #eee));
+  background-size: 200% 100%;
+  animation: office-shimmer 1.4s infinite linear;
+  border-radius: 14px;
+}
+
+@keyframes office-shimmer {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}

--- a/frontend/src/pages/Office.jsx
+++ b/frontend/src/pages/Office.jsx
@@ -1,0 +1,278 @@
+import { useEffect, useState } from 'react';
+import { Navigate } from 'react-router-dom';
+import {
+  Building2,
+  UserPlus,
+  Users,
+  Mail,
+  Crown,
+  Trash2,
+  Plus,
+} from 'lucide-react';
+import api from '../lib/api';
+import { useAuth } from '../lib/auth';
+import { useToast, optimisticUpdate } from '../lib/toast';
+import { displayText } from '../lib/display';
+import EmptyState from '../components/EmptyState';
+import ConfirmDialog from '../components/ConfirmDialog';
+import './Office.css';
+
+// A1 — Office page.
+//
+// For users who belong to an office: show name + member list, let the
+// OWNER invite new members (lookup by email → userId → addOfficeMember)
+// or remove existing members with a confirmation.
+//
+// For users with no office: show a "create office" form (first user
+// becomes OWNER automatically on the server).
+//
+// Non-OWNER members see a read-only members list. Non-OWNERs also
+// shouldn't hit this page at all — we redirect to / if there's no
+// office (i.e. an AGENT without an office doesn't get offered the
+// create form). The OWNER role check reads user.role from useAuth().
+
+export default function Office() {
+  const { user } = useAuth();
+  const toast = useToast();
+  const [office, setOffice] = useState(null);
+  const [members, setMembers] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  // Create-office form
+  const [officeName, setOfficeName] = useState('');
+  const [creating, setCreating] = useState(false);
+
+  // Invite form
+  const [inviteEmail, setInviteEmail] = useState('');
+  const [inviting, setInviting] = useState(false);
+
+  // Confirm-remove dialog
+  const [pendingRemove, setPendingRemove] = useState(null);
+
+  const isOwner = user?.role === 'OWNER';
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const res = await api.getOffice();
+      setOffice(res?.office || null);
+      setMembers(res?.members || []);
+    } catch (e) {
+      if (e?.status === 404) {
+        setOffice(null);
+        setMembers([]);
+      } else {
+        toast.error('שגיאה בטעינת פרטי המשרד');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { load(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, []);
+
+  // Non-owner without an office → send them home. Owners without an
+  // office still see the create form.
+  if (!loading && !office && !isOwner) {
+    return <Navigate to="/" replace />;
+  }
+
+  const handleCreate = async (e) => {
+    e?.preventDefault?.();
+    const name = officeName.trim();
+    if (!name) return;
+    setCreating(true);
+    try {
+      await api.createOffice({ name });
+      toast.success('המשרד נוצר');
+      setOfficeName('');
+      await load();
+    } catch {
+      toast.error('יצירת המשרד נכשלה');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleInvite = async (e) => {
+    e?.preventDefault?.();
+    const email = inviteEmail.trim();
+    if (!email) return;
+    setInviting(true);
+    try {
+      const found = await api.searchAgentByEmail(email);
+      const agent = found?.agent || found?.user;
+      if (!agent?.id) {
+        toast.error('לא נמצא סוכן עם כתובת זו');
+        return;
+      }
+      await api.addOfficeMember({ userId: agent.id });
+      toast.success('הסוכן הוזמן למשרד');
+      setInviteEmail('');
+      await load();
+    } catch {
+      toast.error('ההזמנה נכשלה');
+    } finally {
+      setInviting(false);
+    }
+  };
+
+  const handleRemove = async () => {
+    if (!pendingRemove) return;
+    const id = pendingRemove.id;
+    setPendingRemove(null);
+    try {
+      await optimisticUpdate(toast, {
+        label: 'מסיר…',
+        success: 'החבר הוסר מהמשרד',
+        onSave: () => api.removeOfficeMember(id),
+      });
+      await load();
+    } catch { /* toast handled */ }
+  };
+
+  if (loading) {
+    return (
+      <div className="office-page" dir="rtl">
+        <div className="office-skel" aria-hidden />
+      </div>
+    );
+  }
+
+  // No office yet — owner sees the create form.
+  if (!office) {
+    return (
+      <div className="office-page" dir="rtl">
+        <header className="office-header">
+          <div className="office-title">
+            <Building2 size={22} aria-hidden="true" />
+            <h1>משרד</h1>
+          </div>
+          <p className="office-subtitle">
+            צור/י משרד חדש כדי להזמין סוכנים לעבודה משותפת על נכסים ולקוחות.
+          </p>
+        </header>
+        <section className="office-card" aria-label="יצירת משרד">
+          <form className="office-form" onSubmit={handleCreate}>
+            <label className="office-field">
+              <span>שם המשרד</span>
+              <input
+                type="text"
+                value={officeName}
+                onChange={(e) => setOfficeName(e.target.value)}
+                placeholder="למשל: נדלן הגולן"
+                aria-label="שם המשרד"
+                required
+              />
+            </label>
+            <button
+              type="submit"
+              className="btn btn-primary"
+              disabled={creating || !officeName.trim()}
+            >
+              <Plus size={16} aria-hidden="true" />
+              <span>{creating ? 'יוצר…' : 'צור משרד'}</span>
+            </button>
+          </form>
+        </section>
+      </div>
+    );
+  }
+
+  return (
+    <div className="office-page" dir="rtl">
+      <header className="office-header">
+        <div className="office-title">
+          <Building2 size={22} aria-hidden="true" />
+          <h1>{displayText(office.name)}</h1>
+        </div>
+        <p className="office-subtitle">
+          ניהול המשרד וצוות הסוכנים.
+        </p>
+      </header>
+
+      {isOwner && (
+        <section className="office-card" aria-label="הזמנת סוכן">
+          <h2 className="office-card-title">
+            <UserPlus size={16} aria-hidden="true" />
+            <span>הזמנת סוכן</span>
+          </h2>
+          <form className="office-form office-form-row" onSubmit={handleInvite}>
+            <label className="office-field office-field-grow">
+              <span>אימייל</span>
+              <input
+                type="email"
+                value={inviteEmail}
+                onChange={(e) => setInviteEmail(e.target.value)}
+                placeholder="agent@example.com"
+                aria-label="אימייל הסוכן"
+                dir="ltr"
+                required
+              />
+            </label>
+            <button
+              type="submit"
+              className="btn btn-primary"
+              disabled={inviting || !inviteEmail.trim()}
+            >
+              <Mail size={14} aria-hidden="true" />
+              <span>{inviting ? 'מזמין…' : 'הזמן'}</span>
+            </button>
+          </form>
+        </section>
+      )}
+
+      <section className="office-card" aria-label="חברי המשרד">
+        <h2 className="office-card-title">
+          <Users size={16} aria-hidden="true" />
+          <span>חברי המשרד ({members.length})</span>
+        </h2>
+        {members.length === 0 ? (
+          <EmptyState
+            icon={<Users size={32} />}
+            title="אין עדיין חברים"
+            description={isOwner ? 'הזמן/י סוכנים באמצעות הטופס שלמעלה.' : ''}
+          />
+        ) : (
+          <ul className="office-members">
+            {members.map((m) => (
+              <li key={m.id} className="office-member">
+                <div className="office-member-body">
+                  <div className="office-member-name">
+                    {displayText(m.displayName || m.email)}
+                    {m.role === 'OWNER' && (
+                      <span className="office-member-badge" aria-label="בעלים">
+                        <Crown size={12} aria-hidden="true" /> בעלים
+                      </span>
+                    )}
+                  </div>
+                  <div className="office-member-email">{displayText(m.email)}</div>
+                </div>
+                {isOwner && m.role !== 'OWNER' && (
+                  <button
+                    type="button"
+                    className="btn btn-ghost office-remove"
+                    onClick={() => setPendingRemove(m)}
+                    aria-label={`הסר את ${m.displayName || m.email}`}
+                  >
+                    <Trash2 size={14} aria-hidden="true" />
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {pendingRemove && (
+        <ConfirmDialog
+          title="הסרת חבר"
+          message={`האם להסיר את ${pendingRemove.displayName || pendingRemove.email} מהמשרד?`}
+          confirmLabel="הסר"
+          onConfirm={handleRemove}
+          onClose={() => setPendingRemove(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/Office.jsx
+++ b/frontend/src/pages/Office.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Navigate } from 'react-router-dom';
 import {
   Building2,
@@ -51,7 +51,7 @@ export default function Office() {
 
   const isOwner = user?.role === 'OWNER';
 
-  const load = async () => {
+  const load = useCallback(async () => {
     setLoading(true);
     try {
       const res = await api.getOffice();
@@ -67,9 +67,9 @@ export default function Office() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [toast]);
 
-  useEffect(() => { load(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, []);
+  useEffect(() => { load(); }, [load]);
 
   // Non-owner without an office → send them home. Owners without an
   // office still see the create form.

--- a/frontend/src/pages/PropertyDetail.css
+++ b/frontend/src/pages/PropertyDetail.css
@@ -1221,3 +1221,24 @@
   border-radius: 999px;
   font-weight: 600;
 }
+
+
+/* MLS pipeline preview chips on the card face. */
+.pd-pipeline-preview {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  font-size: 13px;
+}
+.pd-pipeline-label {
+  color: var(--text-muted, #757575);
+}
+.pd-pipeline-chip {
+  font-size: 12px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--bg-subtle, #f5f5f5);
+  color: var(--text-muted, #555);
+  border: 1px solid var(--border-subtle, #e1e1e1);
+}

--- a/frontend/src/pages/PropertyDetail.jsx
+++ b/frontend/src/pages/PropertyDetail.jsx
@@ -25,6 +25,12 @@ import {
   Sparkles,
   Pencil,
   UserPlus,
+  Users,
+  Workflow,
+  Tag,
+  Bell,
+  Activity,
+  Target,
 } from 'lucide-react';
 import api from '../lib/api';
 import { formatFloor } from '../lib/formatFloor';
@@ -44,6 +50,13 @@ import PageTour from '../components/PageTour';
 import PropertyHero from '../components/PropertyHero';
 import PropertyKpiTile from '../components/PropertyKpiTile';
 import PropertyPanelSheet from '../components/PropertyPanelSheet';
+import PropertyPipelineBlock from '../components/PropertyPipelineBlock';
+import PropertyAssigneesPanel from '../components/PropertyAssigneesPanel';
+import AdvertsPanel from '../components/AdvertsPanel';
+import TagPicker from '../components/TagPicker';
+import RemindersPanel from '../components/RemindersPanel';
+import MatchingList from '../components/MatchingList';
+import ActivityPanel from '../components/ActivityPanel';
 import { useCopyFeedback, useViewportMobile } from '../hooks/mobile';
 import { openWhatsApp, shareWithPhotos, shareToInstagramStory } from '../native/share';
 import { isNative } from '../native/platform';
@@ -197,7 +210,11 @@ export default function PropertyDetail() {
   const [panel, setPanel] = useState(() => {
     try {
       const p = new URLSearchParams(window.location.search).get('panel');
-      const allowed = ['marketing', 'owner', 'photos', 'exclusivity', 'notes', 'map'];
+      const allowed = [
+        'marketing', 'owner', 'photos', 'exclusivity', 'notes', 'map',
+        // MLS parity panels
+        'pipeline', 'adverts', 'assignees', 'matching', 'activity', 'reminders',
+      ];
       return allowed.includes(p) ? p : null;
     } catch { return null; }
   });
@@ -978,6 +995,144 @@ export default function PropertyDetail() {
           <div className="dc-map-addr">{property.street}, {property.city}</div>
         </DashCard>
 
+        {/* MLS parity — pipeline (J9) */}
+        <DashCard
+          delay={6}
+          icon={<Workflow size={16} />}
+          title="צנרת תיווך"
+          action={(
+            <button
+              type="button"
+              className="dc-cta"
+              onClick={() => setPanel('pipeline')}
+              aria-label="ערוך צנרת תיווך"
+            >
+              ערוך
+              <ChevronLeft size={14} />
+            </button>
+          )}
+        >
+          <div className="pd-pipeline-preview">
+            <span className="pd-pipeline-label">שלב: </span>
+            <strong>{property.stage || 'WATCHING'}</strong>
+            {property.agentCommissionPct != null && (
+              <span className="pd-pipeline-chip">עמלה {property.agentCommissionPct}%</span>
+            )}
+            {property.sellerSeriousness && property.sellerSeriousness !== 'NONE' && (
+              <span className="pd-pipeline-chip">רצינות {property.sellerSeriousness}</span>
+            )}
+          </div>
+        </DashCard>
+
+        {/* MLS parity — adverts (F1) */}
+        <DashCard
+          delay={6}
+          icon={<Megaphone size={16} />}
+          title="מודעות פרסום"
+          action={(
+            <button
+              type="button"
+              className="dc-cta"
+              onClick={() => setPanel('adverts')}
+              aria-label="נהל מודעות פרסום"
+            >
+              נהל
+              <ChevronLeft size={14} />
+            </button>
+          )}
+        >
+          <p className="dc-empty">לחץ "נהל" לפתיחה</p>
+        </DashCard>
+
+        {/* MLS parity — assignees (J10) */}
+        <DashCard
+          delay={7}
+          icon={<Users size={16} />}
+          title="שותפים לנכס"
+          action={(
+            <button
+              type="button"
+              className="dc-cta"
+              onClick={() => setPanel('assignees')}
+              aria-label="נהל שותפים לנכס"
+            >
+              נהל
+              <ChevronLeft size={14} />
+            </button>
+          )}
+        >
+          <p className="dc-empty">הוסף שותפים מהמשרד לצפייה משותפת</p>
+        </DashCard>
+
+        {/* MLS parity — matching customers (C3 reverse) */}
+        <DashCard
+          delay={7}
+          icon={<Target size={16} />}
+          title="לקוחות תואמים"
+          action={(
+            <button
+              type="button"
+              className="dc-cta"
+              onClick={() => setPanel('matching')}
+              aria-label="הצג לקוחות תואמים"
+            >
+              הצג
+              <ChevronLeft size={14} />
+            </button>
+          )}
+        >
+          <p className="dc-empty">גלה לקוחות במאגר שהנכס תואם את הפרופיל שלהם</p>
+        </DashCard>
+
+        {/* MLS parity — tags (A2) */}
+        <DashCard
+          delay={7}
+          icon={<Tag size={16} />}
+          title="תגיות"
+        >
+          <TagPicker entityType="PROPERTY" entityId={property.id} />
+        </DashCard>
+
+        {/* MLS parity — reminders (D1) */}
+        <DashCard
+          delay={8}
+          icon={<Bell size={16} />}
+          title="תזכורות"
+          action={(
+            <button
+              type="button"
+              className="dc-cta"
+              onClick={() => setPanel('reminders')}
+              aria-label="פתח תזכורות"
+            >
+              פתח
+              <ChevronLeft size={14} />
+            </button>
+          )}
+        >
+          <p className="dc-empty">הוסף תזכורת לפעולה עתידית על הנכס</p>
+        </DashCard>
+
+        {/* MLS parity — activity (H3) */}
+        <DashCard
+          delay={8}
+          icon={<Activity size={16} />}
+          title="פעילות"
+          action={(
+            <button
+              type="button"
+              className="dc-cta"
+              onClick={() => setPanel('activity')}
+              aria-label="הצג פעילות"
+            >
+              הצג
+              <ChevronLeft size={14} />
+            </button>
+          )}
+        >
+          <p className="dc-empty">יומן פעולות שבוצעו על הנכס</p>
+        </DashCard>
+
       </div>
 
       {/* ── Slide-in panels ── */}
@@ -1179,6 +1334,81 @@ export default function PropertyDetail() {
               <Edit3 size={14} />ערוך הערות ומאפיינים
             </button>
           </div>
+        </PropertyPanelSheet>
+      )}
+
+      {/* MLS parity — pipeline (J9) */}
+      {panel === 'pipeline' && (
+        <PropertyPanelSheet
+          title="צנרת תיווך"
+          subtitle="שלב, עמלה, סוכן ראשי, בלעדיות, רצינות מוכר, הערות מתווך"
+          width="lg"
+          onClose={() => setPanel(null)}
+        >
+          <PropertyPipelineBlock
+            property={property}
+            onSaved={() => { load(); }}
+            toast={toast}
+          />
+        </PropertyPanelSheet>
+      )}
+
+      {/* MLS parity — adverts (F1) */}
+      {panel === 'adverts' && (
+        <PropertyPanelSheet
+          title="מודעות פרסום"
+          subtitle="מודעה אחת לכל ערוץ פרסום"
+          width="lg"
+          onClose={() => setPanel(null)}
+        >
+          <AdvertsPanel propertyId={property.id} toast={toast} />
+        </PropertyPanelSheet>
+      )}
+
+      {/* MLS parity — assignees (J10) */}
+      {panel === 'assignees' && (
+        <PropertyPanelSheet
+          title="שותפים לנכס"
+          subtitle="שיוף סוכנים נוספים מהמשרד"
+          width="lg"
+          onClose={() => setPanel(null)}
+        >
+          <PropertyAssigneesPanel propertyId={property.id} toast={toast} />
+        </PropertyPanelSheet>
+      )}
+
+      {/* MLS parity — matching customers (C3 reverse) */}
+      {panel === 'matching' && (
+        <PropertyPanelSheet
+          title="לקוחות תואמים"
+          subtitle="לקוחות שפרופיל החיפוש שלהם תואם לנכס הזה"
+          width="lg"
+          onClose={() => setPanel(null)}
+        >
+          <MatchingList propertyId={property.id} />
+        </PropertyPanelSheet>
+      )}
+
+      {/* MLS parity — reminders (D1) */}
+      {panel === 'reminders' && (
+        <PropertyPanelSheet
+          title="תזכורות לנכס"
+          width="lg"
+          onClose={() => setPanel(null)}
+        >
+          <RemindersPanel scope={{ propertyId: property.id }} />
+        </PropertyPanelSheet>
+      )}
+
+      {/* MLS parity — activity (H3) */}
+      {panel === 'activity' && (
+        <PropertyPanelSheet
+          title="יומן פעילות"
+          subtitle="כל הפעולות שבוצעו על הנכס"
+          width="lg"
+          onClose={() => setPanel(null)}
+        >
+          <ActivityPanel scope={{ propertyId: property.id }} />
         </PropertyPanelSheet>
       )}
 

--- a/frontend/src/pages/Reminders.css
+++ b/frontend/src/pages/Reminders.css
@@ -1,0 +1,204 @@
+.reminders-page {
+  max-width: 880px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.reminders-header { display: flex; flex-direction: column; gap: 4px; }
+
+.reminders-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.reminders-title h1 {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.reminders-subtitle {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+/* Create form */
+.reminders-new {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 14px;
+}
+
+.reminders-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.reminders-form-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.reminders-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 180px;
+}
+
+.reminders-field-grow { flex: 1; }
+
+.reminders-field span {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.reminders-field input,
+.reminders-field textarea {
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg-card);
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: 14px;
+  resize: vertical;
+}
+
+.reminders-field input:focus,
+.reminders-field textarea:focus {
+  outline: 2px solid var(--gold, #c9a14a);
+  outline-offset: 1px;
+}
+
+.reminders-form-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+/* Tabs */
+.reminders-tabs {
+  display: flex;
+  gap: 4px;
+  padding: 4px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  max-width: 520px;
+}
+
+.reminders-tab {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 9px 12px;
+  border: none;
+  border-radius: 11px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.reminders-tab.is-active {
+  background: var(--bg-card);
+  color: var(--text-primary);
+  font-weight: 700;
+  box-shadow: 0 1px 2px rgba(30, 26, 20, 0.08);
+}
+
+.reminders-tab-badge {
+  min-width: 20px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: var(--gold, #c9a14a);
+  color: var(--bg-primary, #fff);
+  font-size: 11px;
+  font-weight: 800;
+}
+
+/* List */
+.reminders-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.reminders-rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.reminders-row {
+  display: flex;
+  gap: 12px;
+  padding: 12px 14px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  align-items: flex-start;
+}
+
+.reminders-row-body { flex: 1; min-width: 0; }
+
+.reminders-row-title {
+  font-weight: 700;
+  color: var(--text-primary);
+  font-size: 14px;
+  margin-block-end: 4px;
+}
+
+.reminders-row-notes {
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin-block-end: 4px;
+}
+
+.reminders-row-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  font-size: 12px;
+  color: var(--text-tertiary, var(--text-secondary));
+}
+
+.reminders-row-actions {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.reminders-delete {
+  color: var(--danger, #c0392b);
+}
+
+.reminders-row-skel {
+  height: 64px;
+  background: linear-gradient(90deg, var(--bg-elevated, #eee), var(--bg-card), var(--bg-elevated, #eee));
+  background-size: 200% 100%;
+  animation: reminders-shimmer 1.4s infinite linear;
+  border-radius: 14px;
+}
+
+@keyframes reminders-shimmer {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}

--- a/frontend/src/pages/Reminders.jsx
+++ b/frontend/src/pages/Reminders.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Bell,
   Check,
@@ -38,7 +38,7 @@ export default function Reminders() {
   const [form, setForm] = useState(EMPTY_FORM);
   const [saving, setSaving] = useState(false);
 
-  const load = async () => {
+  const load = useCallback(async () => {
     setLoading(true);
     try {
       const res = await api.listReminders({ status: tab });
@@ -48,9 +48,9 @@ export default function Reminders() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [tab, toast]);
 
-  useEffect(() => { load(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [tab]);
+  useEffect(() => { load(); }, [load]);
 
   const update = (key, value) => setForm((p) => ({ ...p, [key]: value }));
 

--- a/frontend/src/pages/Reminders.jsx
+++ b/frontend/src/pages/Reminders.jsx
@@ -1,0 +1,271 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Bell,
+  Check,
+  X as XIcon,
+  Trash2,
+  Plus,
+  Clock,
+  CheckCircle2,
+  Ban,
+} from 'lucide-react';
+import api from '../lib/api';
+import { useToast, optimisticUpdate } from '../lib/toast';
+import { displayDateTime, displayText } from '../lib/display';
+import EmptyState from '../components/EmptyState';
+import './Reminders.css';
+
+// D1 — standalone reminders page.
+//
+// Tabs for pending / completed / cancelled, inline create form, and
+// inline row actions (complete / cancel / delete). Reuses optimistic
+// update flow from lib/toast so the UI responds instantly and rolls
+// back on error.
+
+const TABS = [
+  { key: 'PENDING',   label: 'פתוחות',   Icon: Clock },
+  { key: 'COMPLETED', label: 'הושלמו',   Icon: CheckCircle2 },
+  { key: 'CANCELLED', label: 'בוטלו',    Icon: Ban },
+];
+
+const EMPTY_FORM = { title: '', dueAt: '', notes: '' };
+
+export default function Reminders() {
+  const toast = useToast();
+  const [tab, setTab] = useState('PENDING');
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [form, setForm] = useState(EMPTY_FORM);
+  const [saving, setSaving] = useState(false);
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const res = await api.listReminders({ status: tab });
+      setItems(res?.items || []);
+    } catch {
+      toast.error('שגיאה בטעינת תזכורות');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { load(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [tab]);
+
+  const update = (key, value) => setForm((p) => ({ ...p, [key]: value }));
+
+  const handleCreate = async (e) => {
+    e?.preventDefault?.();
+    const title = form.title.trim();
+    if (!title) {
+      toast.error('נדרש תיאור לתזכורת');
+      return;
+    }
+    setSaving(true);
+    try {
+      const body = {
+        title,
+        notes: form.notes.trim() || null,
+        dueAt: form.dueAt ? new Date(form.dueAt).toISOString() : null,
+      };
+      await api.createReminder(body);
+      setForm(EMPTY_FORM);
+      toast.success('תזכורת נוצרה');
+      if (tab !== 'PENDING') setTab('PENDING');
+      else await load();
+    } catch {
+      toast.error('יצירת התזכורת נכשלה');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleComplete = async (id) => {
+    try {
+      await optimisticUpdate(toast, {
+        label: 'מסמן כהושלם…',
+        success: 'התזכורת סומנה כהושלמה',
+        onSave: () => api.completeReminder(id),
+      });
+      await load();
+    } catch { /* toast handled */ }
+  };
+
+  const handleCancel = async (id) => {
+    try {
+      await optimisticUpdate(toast, {
+        label: 'מבטל…',
+        success: 'התזכורת בוטלה',
+        onSave: () => api.cancelReminder(id),
+      });
+      await load();
+    } catch { /* toast handled */ }
+  };
+
+  const handleDelete = async (id) => {
+    try {
+      await optimisticUpdate(toast, {
+        label: 'מוחק…',
+        success: 'התזכורת נמחקה',
+        onSave: () => api.deleteReminder(id),
+      });
+      await load();
+    } catch { /* toast handled */ }
+  };
+
+  const counts = useMemo(() => ({
+    [tab]: items.length,
+  }), [tab, items]);
+
+  return (
+    <div className="reminders-page" dir="rtl">
+      <header className="reminders-header">
+        <div className="reminders-title">
+          <Bell size={22} aria-hidden="true" />
+          <h1>תזכורות</h1>
+        </div>
+        <p className="reminders-subtitle">
+          כל התזכורות שלך במקום אחד — צור חדשה, סמן כבוצעה או בטל.
+        </p>
+      </header>
+
+      <section className="reminders-new" aria-label="תזכורת חדשה">
+        <form className="reminders-form" onSubmit={handleCreate}>
+          <div className="reminders-form-row">
+            <label className="reminders-field reminders-field-grow">
+              <span>תיאור</span>
+              <input
+                type="text"
+                value={form.title}
+                onChange={(e) => update('title', e.target.value)}
+                placeholder="למשל: להתקשר ללקוח"
+                aria-label="תיאור תזכורת"
+                required
+              />
+            </label>
+            <label className="reminders-field">
+              <span>תאריך יעד</span>
+              <input
+                type="datetime-local"
+                value={form.dueAt}
+                onChange={(e) => update('dueAt', e.target.value)}
+                aria-label="תאריך יעד"
+              />
+            </label>
+          </div>
+          <label className="reminders-field">
+            <span>הערות</span>
+            <textarea
+              rows={2}
+              value={form.notes}
+              onChange={(e) => update('notes', e.target.value)}
+              placeholder="פרטים נוספים (לא חובה)"
+              aria-label="הערות"
+            />
+          </label>
+          <div className="reminders-form-actions">
+            <button
+              type="submit"
+              className="btn btn-primary"
+              disabled={saving || !form.title.trim()}
+            >
+              <Plus size={16} aria-hidden="true" />
+              <span>{saving ? 'שומר…' : 'הוסף תזכורת'}</span>
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <div className="reminders-tabs" role="tablist" aria-label="מצב תזכורות">
+        {TABS.map((t) => (
+          <button
+            key={t.key}
+            type="button"
+            role="tab"
+            aria-selected={tab === t.key}
+            className={`reminders-tab ${tab === t.key ? 'is-active' : ''}`}
+            onClick={() => setTab(t.key)}
+          >
+            <t.Icon size={14} aria-hidden="true" />
+            <span>{t.label}</span>
+            {tab === t.key && items.length > 0 && (
+              <span className="reminders-tab-badge">{counts[tab] || 0}</span>
+            )}
+          </button>
+        ))}
+      </div>
+
+      <section
+        className="reminders-list"
+        aria-label={`תזכורות ${tab}`}
+        aria-busy={loading ? 'true' : 'false'}
+      >
+        {loading && items.length === 0 ? (
+          <div className="reminders-skel" aria-hidden>
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="reminders-row reminders-row-skel" />
+            ))}
+          </div>
+        ) : items.length === 0 ? (
+          <EmptyState
+            icon={<Bell size={40} />}
+            title={tab === 'PENDING' ? 'אין תזכורות פתוחות' :
+                   tab === 'COMPLETED' ? 'אין תזכורות שהושלמו' :
+                   'אין תזכורות שבוטלו'}
+            description={tab === 'PENDING'
+              ? 'צור/י תזכורת חדשה בטופס שלמעלה'
+              : ''}
+          />
+        ) : (
+          <ul className="reminders-rows">
+            {items.map((r) => (
+              <li key={r.id} className="reminders-row">
+                <div className="reminders-row-body">
+                  <div className="reminders-row-title">{displayText(r.title)}</div>
+                  {r.notes && <div className="reminders-row-notes">{r.notes}</div>}
+                  <div className="reminders-row-meta">
+                    {r.dueAt && <span>יעד: {displayDateTime(r.dueAt)}</span>}
+                    {r.leadId && <span>ליד: {r.leadId}</span>}
+                    {r.propertyId && <span>נכס: {r.propertyId}</span>}
+                  </div>
+                </div>
+                <div className="reminders-row-actions">
+                  {tab === 'PENDING' && (
+                    <>
+                      <button
+                        type="button"
+                        className="btn btn-secondary"
+                        onClick={() => handleComplete(r.id)}
+                        aria-label={`סמן כהושלם: ${r.title}`}
+                      >
+                        <Check size={14} aria-hidden="true" />
+                        <span>הושלם</span>
+                      </button>
+                      <button
+                        type="button"
+                        className="btn btn-ghost"
+                        onClick={() => handleCancel(r.id)}
+                        aria-label={`בטל: ${r.title}`}
+                      >
+                        <XIcon size={14} aria-hidden="true" />
+                        <span>בטל</span>
+                      </button>
+                    </>
+                  )}
+                  <button
+                    type="button"
+                    className="btn btn-ghost reminders-delete"
+                    onClick={() => handleDelete(r.id)}
+                    aria-label={`מחק: ${r.title}`}
+                  >
+                    <Trash2 size={14} aria-hidden="true" />
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/Reports.css
+++ b/frontend/src/pages/Reports.css
@@ -1,0 +1,147 @@
+.reports-page {
+  max-width: 1040px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding-block: 8px;
+}
+
+.reports-header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.reports-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.reports-title h1 {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.reports-subtitle {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+.reports-filters {
+  padding: 14px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+}
+
+.reports-tiles {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.report-tile {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+}
+
+.report-tile-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  background: var(--bg-elevated, rgba(0,0,0,0.03));
+  color: var(--gold, #c9a14a);
+  flex-shrink: 0;
+}
+
+.report-tile-body { flex: 1; min-width: 0; }
+
+.report-tile-label {
+  font-size: 12px;
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+
+.report-tile-count {
+  font-size: 28px;
+  font-weight: 800;
+  color: var(--text-primary);
+  line-height: 1.1;
+  margin-block-start: 2px;
+}
+
+.report-tile-sub {
+  margin-block-start: 6px;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.reports-status,
+.reports-export {
+  padding: 16px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+}
+
+.reports-status h2,
+.reports-export h2 {
+  margin: 0 0 10px;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.reports-status-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.reports-status-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: var(--bg-elevated, rgba(0,0,0,0.03));
+  border: 1px solid var(--border);
+  font-size: 13px;
+}
+
+.reports-status-label { color: var(--text-secondary); }
+.reports-status-count { font-weight: 700; color: var(--text-primary); }
+
+.reports-export-hint {
+  margin: 0 0 10px;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.reports-export-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.reports-export-actions .btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  text-decoration: none;
+}

--- a/frontend/src/pages/Reports.jsx
+++ b/frontend/src/pages/Reports.jsx
@@ -1,0 +1,179 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  BarChart3,
+  Building2,
+  Users,
+  Handshake,
+  CalendarDays,
+  Megaphone,
+  Download,
+} from 'lucide-react';
+import api from '../lib/api';
+import { useToast } from '../lib/toast';
+import { displayPrice } from '../lib/display';
+import DateRangePicker from '../components/DateRangePicker';
+import './Reports.css';
+
+// E1 — Reports page.
+//
+// Pulls the five owner-scoped report endpoints in parallel whenever the
+// date range changes. Counts surface as KPI tiles; the Deals tile adds
+// a sub-line with total commission and per-status breakdown. B5 CSV
+// export buttons render as <a href={api.exportUrl(kind)}> — the API
+// helper returns a URL string, the browser handles the download.
+
+const CSV_KINDS = [
+  { kind: 'properties', label: 'נכסים',  Icon: Building2 },
+  { kind: 'leads',      label: 'לקוחות',  Icon: Users },
+  { kind: 'deals',      label: 'עסקאות',  Icon: Handshake },
+];
+
+const STATUS_LABELS = {
+  OPEN:      'פתוחה',
+  PENDING:   'בהמתנה',
+  WON:       'נסגרה',
+  LOST:      'אבדה',
+  CANCELLED: 'בוטלה',
+};
+
+export default function Reports() {
+  const toast = useToast();
+  const [from, setFrom] = useState('');
+  const [to,   setTo]   = useState('');
+  const [loading, setLoading] = useState(true);
+  const [data, setData] = useState({
+    newProperties:     { count: 0 },
+    newCustomers:      { count: 0 },
+    deals:             { count: 0, totalCommission: 0, byStatus: {} },
+    viewings:          { count: 0 },
+    marketingActions:  { count: 0 },
+  });
+
+  const params = useMemo(() => {
+    const p = {};
+    if (from) p.from = from;
+    if (to)   p.to   = to;
+    return p;
+  }, [from, to]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      try {
+        const [nProps, nCust, deals, views, mkt] = await Promise.all([
+          api.reportNewProperties(params).catch(() => ({ count: 0 })),
+          api.reportNewCustomers(params).catch(() => ({ count: 0 })),
+          api.reportDeals(params).catch(() => ({ count: 0, totalCommission: 0, byStatus: {} })),
+          api.reportViewings(params).catch(() => ({ count: 0 })),
+          api.reportMarketingActions(params).catch(() => ({ count: 0 })),
+        ]);
+        if (cancelled) return;
+        setData({
+          newProperties:    nProps,
+          newCustomers:     nCust,
+          deals,
+          viewings:         views,
+          marketingActions: mkt,
+        });
+      } catch {
+        if (!cancelled) toast.error('שגיאה בטעינת הדוחות');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [params, toast]);
+
+  const onDateChange = ({ from: f, to: t }) => { setFrom(f); setTo(t); };
+
+  const tiles = [
+    { key: 'properties', label: 'נכסים חדשים',  Icon: Building2,   count: data.newProperties?.count || 0 },
+    { key: 'customers',  label: 'לקוחות חדשים',  Icon: Users,       count: data.newCustomers?.count || 0 },
+    { key: 'deals',      label: 'עסקאות',        Icon: Handshake,   count: data.deals?.count || 0 },
+    { key: 'viewings',   label: 'צפיות',         Icon: CalendarDays, count: data.viewings?.count || 0 },
+    { key: 'marketing',  label: 'פעולות שיווק', Icon: Megaphone,   count: data.marketingActions?.count || 0 },
+  ];
+
+  const byStatus = data.deals?.byStatus || {};
+  const byStatusEntries = Object.entries(byStatus);
+
+  return (
+    <div className="reports-page" dir="rtl">
+      <header className="reports-header">
+        <div className="reports-title">
+          <BarChart3 size={22} aria-hidden="true" />
+          <h1>דוחות</h1>
+        </div>
+        <p className="reports-subtitle">
+          סקירת ביצועים לפי טווח תאריכים. בחר/י טווח והמספרים יתעדכנו.
+        </p>
+      </header>
+
+      <section className="reports-filters" aria-label="מסנני דוח">
+        <DateRangePicker from={from} to={to} onChange={onDateChange} />
+      </section>
+
+      <section
+        className="reports-tiles"
+        aria-label="תוצאות הדוח"
+        aria-busy={loading ? 'true' : 'false'}
+      >
+        {tiles.map((t) => (
+          <article key={t.key} className="report-tile">
+            <div className="report-tile-icon" aria-hidden="true">
+              <t.Icon size={20} />
+            </div>
+            <div className="report-tile-body">
+              <div className="report-tile-label">{t.label}</div>
+              <div className="report-tile-count">{t.count}</div>
+              {t.key === 'deals' && (
+                <div className="report-tile-sub">
+                  <span>עמלה כוללת: </span>
+                  <strong>{displayPrice(data.deals?.totalCommission ?? 0)}</strong>
+                </div>
+              )}
+            </div>
+          </article>
+        ))}
+      </section>
+
+      {byStatusEntries.length > 0 && (
+        <section className="reports-status" aria-label="פילוח עסקאות לפי סטטוס">
+          <h2>עסקאות לפי סטטוס</h2>
+          <ul className="reports-status-list">
+            {byStatusEntries.map(([status, count]) => (
+              <li key={status} className="reports-status-item">
+                <span className="reports-status-label">
+                  {STATUS_LABELS[status] || status}
+                </span>
+                <span className="reports-status-count">{count}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      <section className="reports-export" aria-label="ייצוא CSV">
+        <h2>ייצוא CSV</h2>
+        <p className="reports-export-hint">
+          הקבצים מיוצאים לפי הנתונים הזמינים בחשבון שלך.
+        </p>
+        <div className="reports-export-actions">
+          {CSV_KINDS.map((c) => (
+            <a
+              key={c.kind}
+              href={api.exportUrl(c.kind)}
+              download
+              className="btn btn-secondary"
+              data-testid={`csv-${c.kind}`}
+            >
+              <Download size={16} aria-hidden="true" />
+              <span>ייצוא {c.label}</span>
+            </a>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/TagSettings.css
+++ b/frontend/src/pages/TagSettings.css
@@ -1,0 +1,163 @@
+.tags-page {
+  max-width: 920px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.tags-header { display: flex; flex-direction: column; gap: 4px; }
+
+.tags-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.tags-title h1 {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.tags-subtitle {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+.tags-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 14px;
+}
+
+.tags-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: flex-end;
+}
+
+.tags-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 120px;
+}
+
+.tags-field-grow { flex: 1; min-width: 180px; }
+
+.tags-field span {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.tags-field input[type="text"],
+.tags-field select {
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg-card);
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: 14px;
+}
+
+.tags-field input[type="text"]:focus,
+.tags-field select:focus {
+  outline: 2px solid var(--gold, #c9a14a);
+  outline-offset: 1px;
+}
+
+.tags-color {
+  width: 44px;
+  height: 40px;
+  padding: 2px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg-card);
+  cursor: pointer;
+}
+
+/* List */
+.tags-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.tags-rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.tags-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+}
+
+.tags-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 12px;
+  border-radius: 999px;
+  color: #fff;
+  font-weight: 700;
+  font-size: 13px;
+}
+
+.tags-scope {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.tags-actions {
+  margin-inline-start: auto;
+  display: flex;
+  gap: 4px;
+}
+
+.tags-delete { color: var(--danger, #c0392b); }
+
+.tags-edit {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  width: 100%;
+  align-items: center;
+}
+
+.tags-edit-name {
+  flex: 1;
+  min-width: 160px;
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  font-family: var(--font-body);
+  font-size: 14px;
+}
+
+.tags-skel {
+  height: 160px;
+  background: linear-gradient(90deg, var(--bg-elevated, #eee), var(--bg-card), var(--bg-elevated, #eee));
+  background-size: 200% 100%;
+  animation: tags-shimmer 1.4s infinite linear;
+  border-radius: 14px;
+}
+
+@keyframes tags-shimmer {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}

--- a/frontend/src/pages/TagSettings.jsx
+++ b/frontend/src/pages/TagSettings.jsx
@@ -1,0 +1,285 @@
+import { useEffect, useState } from 'react';
+import { Tag, Plus, Trash2, Pencil, Check, X as XIcon } from 'lucide-react';
+import api from '../lib/api';
+import { useToast, optimisticUpdate } from '../lib/toast';
+import { displayText } from '../lib/display';
+import EmptyState from '../components/EmptyState';
+import ConfirmDialog from '../components/ConfirmDialog';
+import './TagSettings.css';
+
+// A2 — Tag library CRUD.
+//
+// Lists every tag in the owner-scope, inline create-new form, and
+// edit-in-place rows with a confirm-dialog on delete so an accidental
+// click doesn't nuke an entity-wide label.
+
+const SCOPE_OPTIONS = [
+  { value: 'ALL',      label: 'הכל' },
+  { value: 'PROPERTY', label: 'נכס' },
+  { value: 'LEAD',     label: 'ליד' },
+  { value: 'CUSTOMER', label: 'לקוח' },
+];
+
+const DEFAULT_COLOR = '#c9a14a';
+
+const EMPTY_FORM = { name: '', color: DEFAULT_COLOR, scope: 'ALL' };
+
+export default function TagSettings() {
+  const toast = useToast();
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [form, setForm] = useState(EMPTY_FORM);
+  const [saving, setSaving] = useState(false);
+  const [editing, setEditing] = useState(null); // {id, name, color, scope}
+  const [pendingDelete, setPendingDelete] = useState(null);
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const res = await api.listTags();
+      setItems(res?.items || []);
+    } catch {
+      toast.error('שגיאה בטעינת התגיות');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { load(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, []);
+
+  const updateForm = (key, value) => setForm((p) => ({ ...p, [key]: value }));
+
+  const handleCreate = async (e) => {
+    e?.preventDefault?.();
+    const name = form.name.trim();
+    if (!name) return;
+    setSaving(true);
+    try {
+      await api.createTag({ name, color: form.color || null, scope: form.scope });
+      toast.success('התגית נוספה');
+      setForm(EMPTY_FORM);
+      await load();
+    } catch {
+      toast.error('יצירת התגית נכשלה');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleStartEdit = (tag) => {
+    setEditing({
+      id: tag.id,
+      name: tag.name,
+      color: tag.color || DEFAULT_COLOR,
+      scope: tag.scope || 'ALL',
+    });
+  };
+
+  const handleCancelEdit = () => setEditing(null);
+
+  const handleSaveEdit = async () => {
+    if (!editing?.id) return;
+    try {
+      await optimisticUpdate(toast, {
+        label: 'שומר…',
+        success: 'התגית עודכנה',
+        onSave: () => api.updateTag(editing.id, {
+          name: editing.name.trim(),
+          color: editing.color || null,
+          scope: editing.scope,
+        }),
+      });
+      setEditing(null);
+      await load();
+    } catch { /* toast handled */ }
+  };
+
+  const handleDelete = async () => {
+    if (!pendingDelete) return;
+    const id = pendingDelete.id;
+    setPendingDelete(null);
+    try {
+      await optimisticUpdate(toast, {
+        label: 'מוחק…',
+        success: 'התגית נמחקה',
+        onSave: () => api.deleteTag(id),
+      });
+      await load();
+    } catch { /* toast handled */ }
+  };
+
+  return (
+    <div className="tags-page" dir="rtl">
+      <header className="tags-header">
+        <div className="tags-title">
+          <Tag size={22} aria-hidden="true" />
+          <h1>תגיות</h1>
+        </div>
+        <p className="tags-subtitle">
+          ניהול ספריית התגיות לשיוך נכסים, לקוחות ולידים.
+        </p>
+      </header>
+
+      <section className="tags-card" aria-label="תגית חדשה">
+        <form className="tags-form" onSubmit={handleCreate}>
+          <label className="tags-field tags-field-grow">
+            <span>שם התגית</span>
+            <input
+              type="text"
+              value={form.name}
+              onChange={(e) => updateForm('name', e.target.value)}
+              placeholder="למשל: VIP"
+              aria-label="שם התגית"
+              required
+            />
+          </label>
+          <label className="tags-field">
+            <span>צבע</span>
+            <input
+              type="color"
+              value={form.color}
+              onChange={(e) => updateForm('color', e.target.value)}
+              aria-label="צבע התגית"
+              className="tags-color"
+            />
+          </label>
+          <label className="tags-field">
+            <span>תחום</span>
+            <select
+              value={form.scope}
+              onChange={(e) => updateForm('scope', e.target.value)}
+              aria-label="תחום תגית"
+            >
+              {SCOPE_OPTIONS.map((s) => (
+                <option key={s.value} value={s.value}>{s.label}</option>
+              ))}
+            </select>
+          </label>
+          <button
+            type="submit"
+            className="btn btn-primary"
+            disabled={saving || !form.name.trim()}
+          >
+            <Plus size={16} aria-hidden="true" />
+            <span>{saving ? 'שומר…' : 'הוסף תגית'}</span>
+          </button>
+        </form>
+      </section>
+
+      <section
+        className="tags-list"
+        aria-label="רשימת תגיות"
+        aria-busy={loading ? 'true' : 'false'}
+      >
+        {loading && items.length === 0 ? (
+          <div className="tags-skel" aria-hidden />
+        ) : items.length === 0 ? (
+          <EmptyState
+            icon={<Tag size={40} />}
+            title="עדיין אין תגיות"
+            description="הוסף/י תגית ראשונה בטופס שלמעלה כדי לסווג נכסים ולקוחות."
+          />
+        ) : (
+          <ul className="tags-rows">
+            {items.map((t) => {
+              const isEditing = editing?.id === t.id;
+              return (
+                <li key={t.id} className="tags-row">
+                  {isEditing ? (
+                    <div className="tags-edit">
+                      <input
+                        className="tags-edit-name"
+                        type="text"
+                        value={editing.name}
+                        onChange={(e) =>
+                          setEditing((p) => ({ ...p, name: e.target.value }))
+                        }
+                        aria-label="שם תגית"
+                      />
+                      <input
+                        type="color"
+                        value={editing.color}
+                        onChange={(e) =>
+                          setEditing((p) => ({ ...p, color: e.target.value }))
+                        }
+                        aria-label="צבע תגית"
+                        className="tags-color"
+                      />
+                      <select
+                        value={editing.scope}
+                        onChange={(e) =>
+                          setEditing((p) => ({ ...p, scope: e.target.value }))
+                        }
+                        aria-label="תחום תגית"
+                      >
+                        {SCOPE_OPTIONS.map((s) => (
+                          <option key={s.value} value={s.value}>{s.label}</option>
+                        ))}
+                      </select>
+                      <button
+                        type="button"
+                        className="btn btn-primary"
+                        onClick={handleSaveEdit}
+                        aria-label="שמור"
+                      >
+                        <Check size={14} aria-hidden="true" />
+                      </button>
+                      <button
+                        type="button"
+                        className="btn btn-ghost"
+                        onClick={handleCancelEdit}
+                        aria-label="בטל עריכה"
+                      >
+                        <XIcon size={14} aria-hidden="true" />
+                      </button>
+                    </div>
+                  ) : (
+                    <>
+                      <span
+                        className="tags-chip"
+                        style={{ background: t.color || DEFAULT_COLOR }}
+                      >
+                        {displayText(t.name)}
+                      </span>
+                      <span className="tags-scope">
+                        {SCOPE_OPTIONS.find((s) => s.value === t.scope)?.label || t.scope}
+                      </span>
+                      <div className="tags-actions">
+                        <button
+                          type="button"
+                          className="btn btn-ghost"
+                          onClick={() => handleStartEdit(t)}
+                          aria-label={`ערוך: ${t.name}`}
+                        >
+                          <Pencil size={14} aria-hidden="true" />
+                        </button>
+                        <button
+                          type="button"
+                          className="btn btn-ghost tags-delete"
+                          onClick={() => setPendingDelete(t)}
+                          aria-label={`מחק: ${t.name}`}
+                        >
+                          <Trash2 size={14} aria-hidden="true" />
+                        </button>
+                      </div>
+                    </>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+
+      {pendingDelete && (
+        <ConfirmDialog
+          title="מחיקת תגית"
+          message={`האם למחוק את התגית "${pendingDelete.name}"? השיוכים הקיימים יוסרו.`}
+          confirmLabel="מחק"
+          onConfirm={handleDelete}
+          onClose={() => setPendingDelete(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/TagSettings.jsx
+++ b/frontend/src/pages/TagSettings.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Tag, Plus, Trash2, Pencil, Check, X as XIcon } from 'lucide-react';
 import api from '../lib/api';
 import { useToast, optimisticUpdate } from '../lib/toast';
@@ -33,7 +33,7 @@ export default function TagSettings() {
   const [editing, setEditing] = useState(null); // {id, name, color, scope}
   const [pendingDelete, setPendingDelete] = useState(null);
 
-  const load = async () => {
+  const load = useCallback(async () => {
     setLoading(true);
     try {
       const res = await api.listTags();
@@ -43,9 +43,9 @@ export default function TagSettings() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [toast]);
 
-  useEffect(() => { load(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, []);
+  useEffect(() => { load(); }, [load]);
 
   const updateForm = (key, value) => setForm((p) => ({ ...p, [key]: value }));
 

--- a/tests/frontend/components/composites/AddressField.test.tsx
+++ b/tests/frontend/components/composites/AddressField.test.tsx
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi } from 'vitest';
+import { useState } from 'react';
+import { http, HttpResponse } from 'msw';
+import { render, screen, userEvent, waitFor } from '../../setup/test-utils';
+import { server } from '../../setup/msw-server';
+import AddressField from '@estia/frontend/components/AddressField.jsx';
+
+// The AddressField already handles the street typeahead via Photon; the
+// G1 addition is an optional `neighborhood` value + `onNeighborhoodChange`
+// callback that fires a second suggestions list from /api/neighborhoods,
+// scoped to the city on the component. Only exercised when the parent
+// opts in by rendering a secondary field (a new "שכונה" input the picker
+// surfaces beneath the street box).
+
+function Harness({ city = 'תל אביב' }: { city?: string }) {
+  const [val, setVal] = useState('');
+  const [nb, setNb] = useState('');
+  return (
+    <AddressField
+      value={val}
+      onChange={setVal}
+      city={city}
+      neighborhood={nb}
+      onNeighborhoodChange={setNb}
+      showNeighborhood
+      aria-label="כתובת"
+    />
+  );
+}
+
+describe('<AddressField> neighborhood autocomplete', () => {
+  it('does not fetch neighborhoods when no city is set', async () => {
+    let called = false;
+    server.use(
+      http.get('/api/neighborhoods', () => {
+        called = true;
+        return HttpResponse.json({ items: [] });
+      }),
+    );
+    const { rerender } = render(
+      <AddressField
+        value=""
+        onChange={() => {}}
+        neighborhood=""
+        onNeighborhoodChange={() => {}}
+        showNeighborhood
+        aria-label="כתובת"
+      />
+    );
+    // No city prop at all — neighborhood input is there but disabled.
+    const nbInput = screen.getByLabelText('שכונה') as HTMLInputElement;
+    expect(nbInput).toBeDisabled();
+    // Re-render passing an empty string city — still disabled, still no call.
+    rerender(
+      <AddressField
+        value=""
+        onChange={() => {}}
+        city=""
+        neighborhood=""
+        onNeighborhoodChange={() => {}}
+        showNeighborhood
+        aria-label="כתובת"
+      />
+    );
+    expect(screen.getByLabelText('שכונה')).toBeDisabled();
+    await new Promise((r) => setTimeout(r, 250));
+    expect(called).toBe(false);
+  });
+
+  it('fires the neighborhood fetch only after a city is set + user types', async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.get('/api/neighborhoods', ({ request }) => {
+        const url = new URL(request.url);
+        expect(url.searchParams.get('city')).toBe('תל אביב');
+        return HttpResponse.json({
+          items: [
+            { id: 'n1', city: 'תל אביב', name: 'פלורנטין', aliases: [] },
+          ],
+        });
+      }),
+    );
+    render(<Harness />);
+    const nbInput = screen.getByLabelText('שכונה');
+    expect(nbInput).not.toBeDisabled();
+    await user.type(nbInput, 'פלו');
+    // Suggestions list appears.
+    expect(
+      await screen.findByRole('option', { name: /פלורנטין/ }, { timeout: 2000 })
+    ).toBeInTheDocument();
+  });
+
+  it('commits the picked neighborhood via onNeighborhoodChange', async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.get('/api/neighborhoods', () =>
+        HttpResponse.json({
+          items: [{ id: 'n1', city: 'תל אביב', name: 'פלורנטין', aliases: [] }],
+        })
+      ),
+    );
+    const onNeighborhoodChange = vi.fn();
+    render(
+      <AddressField
+        value=""
+        onChange={() => {}}
+        city="תל אביב"
+        neighborhood=""
+        onNeighborhoodChange={onNeighborhoodChange}
+        showNeighborhood
+        aria-label="כתובת"
+      />
+    );
+    const nbInput = screen.getByLabelText('שכונה');
+    await user.type(nbInput, 'פלו');
+    const option = await screen.findByRole('option', { name: /פלורנטין/ });
+    await user.click(option);
+    expect(onNeighborhoodChange).toHaveBeenLastCalledWith('פלורנטין');
+  });
+
+  it('keeps free-text input when the user ignores suggestions', async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.get('/api/neighborhoods', () => HttpResponse.json({ items: [] })),
+    );
+    const onNeighborhoodChange = vi.fn();
+    render(
+      <AddressField
+        value=""
+        onChange={() => {}}
+        city="תל אביב"
+        neighborhood=""
+        onNeighborhoodChange={onNeighborhoodChange}
+        showNeighborhood
+        aria-label="כתובת"
+      />
+    );
+    const nbInput = screen.getByLabelText('שכונה');
+    await user.type(nbInput, 'שכונה חדשה');
+    await waitFor(() => {
+      expect((nbInput as HTMLInputElement).value).toBe('שכונה חדשה');
+    });
+    // Free text propagates via onNeighborhoodChange as the user types
+    // — the parent stores it even without a suggestion pick.
+    expect(onNeighborhoodChange).toHaveBeenCalledWith('שכונה חדשה');
+  });
+
+  it('still works when showNeighborhood is not passed — no regression for existing callers', () => {
+    // This is the existing contract: AddressField with no neighborhood
+    // props still renders its street input and nothing else.
+    render(
+      <AddressField
+        value=""
+        onChange={() => {}}
+        city="תל אביב"
+        aria-label="כתובת"
+      />
+    );
+    expect(screen.queryByLabelText('שכונה')).toBeNull();
+    // Street input is present as always.
+    expect(screen.getByLabelText('כתובת')).toBeInTheDocument();
+  });
+});

--- a/tests/frontend/components/composites/AdvertsPanel.test.tsx
+++ b/tests/frontend/components/composites/AdvertsPanel.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { axe } from 'vitest-axe';
+import { render, screen, userEvent, waitFor } from '../../setup/test-utils';
+import { server } from '../../setup/msw-server';
+import AdvertsPanel from '@estia/frontend/components/AdvertsPanel.jsx';
+
+describe('<AdvertsPanel>', () => {
+  it('renders the empty state when the property has no adverts', async () => {
+    render(<AdvertsPanel propertyId="p1" />);
+    await waitFor(() => expect(screen.getByText('אין עדיין מודעות')).toBeInTheDocument());
+  });
+
+  it('renders each advert with its channel + status labels', async () => {
+    server.use(
+      http.get('/api/properties/:id/adverts', () =>
+        HttpResponse.json({
+          items: [
+            {
+              id: 'a1', channel: 'YAD2', status: 'PUBLISHED',
+              title: '4 חד׳ ברח׳ הרצל', publishedPrice: 2500000,
+              externalUrl: 'https://yad2.example', externalId: 'y1',
+              publishedAt: '2026-04-01T00:00:00Z', expiresAt: null,
+            },
+            {
+              id: 'a2', channel: 'FACEBOOK', status: 'DRAFT',
+              title: null, publishedPrice: null,
+              externalUrl: null, externalId: null,
+              publishedAt: null, expiresAt: null,
+            },
+          ],
+        })
+      )
+    );
+    render(<AdvertsPanel propertyId="p1" />);
+    await waitFor(() => expect(screen.getByText('יד2')).toBeInTheDocument());
+    expect(screen.getByText('פייסבוק')).toBeInTheDocument();
+    expect(screen.getByText('4 חד׳ ברח׳ הרצל')).toBeInTheDocument();
+  });
+
+  it('creates a draft advert with the selected channel + title', async () => {
+    const user = userEvent.setup();
+    let postBody: Record<string, unknown> | null = null;
+    server.use(
+      http.post('/api/properties/:id/adverts', async ({ request }) => {
+        postBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ advert: { id: 'new-1', ...postBody } });
+      })
+    );
+    render(<AdvertsPanel propertyId="p1" />);
+    await waitFor(() => expect(screen.getByText('אין עדיין מודעות')).toBeInTheDocument());
+    // Click the empty-state primary CTA ("מודעה חדשה").
+    const newBtns = screen.getAllByRole('button', { name: /מודעה חדשה/ });
+    await user.click(newBtns[0]);
+    await user.type(screen.getByLabelText('כותרת'), 'דירת 4 חדרים');
+    await user.selectOptions(screen.getByLabelText('ערוץ המודעה'), 'ONMAP');
+    await user.click(screen.getByRole('button', { name: 'שמור מודעה' }));
+    await waitFor(() => expect(postBody).toBeTruthy());
+    expect(postBody!.channel).toBe('ONMAP');
+    expect(postBody!.title).toBe('דירת 4 חדרים');
+    expect(postBody!.status).toBe('DRAFT');
+  });
+
+  it('transitions status from DRAFT to PUBLISHED via the inline select', async () => {
+    const user = userEvent.setup();
+    let patchBody: Record<string, unknown> | null = null;
+    server.use(
+      http.get('/api/properties/:id/adverts', () =>
+        HttpResponse.json({
+          items: [
+            {
+              id: 'a1', channel: 'YAD2', status: 'DRAFT',
+              title: 't', publishedPrice: 2500000,
+              externalUrl: null, externalId: null,
+              publishedAt: null, expiresAt: null,
+            },
+          ],
+        })
+      ),
+      http.patch('/api/adverts/:id', async ({ request }) => {
+        patchBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ advert: { id: 'a1', status: patchBody!.status } });
+      })
+    );
+    render(<AdvertsPanel propertyId="p1" />);
+    await waitFor(() => expect(screen.getByText('יד2')).toBeInTheDocument());
+    const statusSelect = screen.getByLabelText(/שנה סטטוס למודעה ביד2/) as HTMLSelectElement;
+    await user.selectOptions(statusSelect, 'PUBLISHED');
+    await waitFor(() => expect(patchBody).toBeTruthy());
+    expect(patchBody!.status).toBe('PUBLISHED');
+    expect(typeof patchBody!.publishedAt).toBe('string');
+  });
+
+  it('removes an advert when the per-row remove button is clicked', async () => {
+    const user = userEvent.setup();
+    let deletedId: string | null = null;
+    server.use(
+      http.get('/api/properties/:id/adverts', () =>
+        HttpResponse.json({
+          items: [{
+            id: 'a1', channel: 'YAD2', status: 'DRAFT',
+            title: 't', publishedPrice: null,
+            externalUrl: null, externalId: null,
+            publishedAt: null, expiresAt: null,
+          }],
+        })
+      ),
+      http.delete('/api/adverts/:id', ({ params }) => {
+        deletedId = params.id as string;
+        return HttpResponse.json({ ok: true });
+      })
+    );
+    render(<AdvertsPanel propertyId="p1" />);
+    await waitFor(() => expect(screen.getByText('יד2')).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: /הסר את המודעה ביד2/ }));
+    await waitFor(() => expect(deletedId).toBe('a1'));
+  });
+
+  it('has no axe violations', async () => {
+    const { baseElement } = render(<AdvertsPanel propertyId="p1" />);
+    await waitFor(() => expect(screen.getByText('אין עדיין מודעות')).toBeInTheDocument());
+    expect(await axe(baseElement)).toHaveNoViolations();
+  });
+});

--- a/tests/frontend/components/composites/CommandPalette.test.tsx
+++ b/tests/frontend/components/composites/CommandPalette.test.tsx
@@ -1,0 +1,117 @@
+// CommandPalette tests — exercises the H1 global-search integration.
+//
+// The palette merges three content sources:
+//  1. Static nav entries (always available, even when offline)
+//  2. Async `api.globalSearch(q)` results, debounced 250ms
+//  3. Grouped into ניווט / נכסים / לקוחות / בעלים / עסקאות
+//
+// We stub the server via MSW so tests don't need to mock the api client.
+
+import { describe, it, expect, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../setup/msw-server';
+import { render, screen, userEvent, waitFor } from '../../setup/test-utils';
+import CommandPalette from '@estia/frontend/components/CommandPalette.jsx';
+
+describe('<CommandPalette>', () => {
+  it('renders the search input and static nav entries when opened', () => {
+    render(<CommandPalette open={true} onClose={() => {}} />);
+    // Placeholder wording is the anchor — stable across Hebrew copy tweaks
+    expect(screen.getByPlaceholderText(/חפש/)).toBeInTheDocument();
+    // Static nav always visible on first open
+    expect(screen.getAllByText('לוח בקרה').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('נכסים').length).toBeGreaterThan(0);
+  });
+
+  it('closes when ESC is pressed', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(<CommandPalette open={true} onClose={onClose} />);
+    await user.keyboard('{Escape}');
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('calls api.globalSearch and renders grouped results (properties, leads, owners, deals)', async () => {
+    server.use(
+      http.get('/api/search', () =>
+        HttpResponse.json({
+          query: 'test',
+          total: 4,
+          properties: [
+            { id: 'p1', street: 'אלנבי', number: '10', city: 'תל אביב' },
+          ],
+          leads: [
+            { id: 'l1', name: 'דנה כהן', phone: '050-0000000', city: 'חיפה' },
+          ],
+          owners: [
+            { id: 'o1', name: 'יוסי לוי', phone: '054-1111111' },
+          ],
+          deals: [
+            { id: 'd1', status: 'OPEN', propertyAddress: 'רחוב הרצל 5' },
+          ],
+        })
+      )
+    );
+    const user = userEvent.setup();
+    render(<CommandPalette open={true} onClose={() => {}} />);
+    const input = screen.getByPlaceholderText(/חפש/);
+    await user.type(input, 'test');
+    // Results grouped under the Hebrew section titles — wait for async debounce.
+    await waitFor(() => {
+      expect(screen.getByText('דנה כהן')).toBeInTheDocument();
+    }, { timeout: 2000 });
+    expect(screen.getByText('יוסי לוי')).toBeInTheDocument();
+    // Section titles visible for at least the dynamic groups
+    expect(screen.getByText('לקוחות')).toBeInTheDocument();
+    expect(screen.getByText('בעלים')).toBeInTheDocument();
+    expect(screen.getByText('עסקאות')).toBeInTheDocument();
+  });
+
+  it('arrow keys move selection and Enter triggers navigation + onClose', async () => {
+    // Server returns one property — pressing Enter on it should close.
+    server.use(
+      http.get('/api/search', () =>
+        HttpResponse.json({
+          query: 'x',
+          total: 1,
+          properties: [{ id: 'px', street: 'דיזנגוף', number: '1', city: 'תל אביב' }],
+          leads: [],
+          owners: [],
+          deals: [],
+        })
+      )
+    );
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(<CommandPalette open={true} onClose={onClose} />);
+    await user.type(screen.getByPlaceholderText(/חפש/), 'x');
+    await waitFor(() => {
+      expect(screen.getByText(/דיזנגוף/)).toBeInTheDocument();
+    }, { timeout: 2000 });
+    // ArrowDown a few times then Enter — implementation should land on the
+    // property and navigate, which closes the palette.
+    await user.keyboard('{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}{Enter}');
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it('shows an empty state when the query has no matches', async () => {
+    server.use(
+      http.get('/api/search', () =>
+        HttpResponse.json({
+          query: 'zzzz',
+          total: 0,
+          properties: [],
+          leads: [],
+          owners: [],
+          deals: [],
+        })
+      )
+    );
+    const user = userEvent.setup();
+    render(<CommandPalette open={true} onClose={() => {}} />);
+    await user.type(screen.getByPlaceholderText(/חפש/), 'zzzz');
+    await waitFor(() => {
+      expect(screen.getByText(/לא נמצאו תוצאות/)).toBeInTheDocument();
+    }, { timeout: 2000 });
+  });
+});

--- a/tests/frontend/components/composites/CustomerFiltersPanel.test.tsx
+++ b/tests/frontend/components/composites/CustomerFiltersPanel.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { render, screen, userEvent, waitFor } from '../../setup/test-utils';
+import { server } from '../../setup/msw-server';
+import CustomerFiltersPanel from '@estia/frontend/components/CustomerFiltersPanel.jsx';
+
+function baseProps(overrides = {}) {
+  return {
+    open: true,
+    filters: {},
+    onApply: vi.fn(),
+    onClose: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('<CustomerFiltersPanel>', () => {
+  it('renders nothing visible when open=false', () => {
+    render(<CustomerFiltersPanel {...baseProps({ open: false })} />);
+    // No dialog in the document — the panel portals out to body when open.
+    expect(screen.queryByRole('dialog')).toBeNull();
+    expect(document.querySelector('.cfp-backdrop')).toBeNull();
+  });
+
+  it('renders a modal dialog with aria-modal=true and an accessible title', () => {
+    render(<CustomerFiltersPanel {...baseProps()} />);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(screen.getByText('סינון מתקדם')).toBeInTheDocument();
+  });
+
+  it('closes on Escape (focus trap + onClose)', async () => {
+    const user = userEvent.setup({ delay: null });
+    const onClose = vi.fn();
+    render(<CustomerFiltersPanel {...baseProps({ onClose })} />);
+    await user.keyboard('{Escape}');
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('closes when the backdrop is clicked', async () => {
+    const user = userEvent.setup({ delay: null });
+    const onClose = vi.fn();
+    render(<CustomerFiltersPanel {...baseProps({ onClose })} />);
+    const backdrop = document.querySelector('.cfp-backdrop');
+    expect(backdrop).toBeTruthy();
+    await user.click(backdrop as HTMLElement);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('applies the assembled filter object when the primary button is clicked', async () => {
+    const user = userEvent.setup({ delay: null });
+    const onApply = vi.fn();
+    render(<CustomerFiltersPanel {...baseProps({ onApply })} />);
+    // Toggle the "חם" (hot) chip under the lead-heat group.
+    await user.click(screen.getByRole('button', { name: /^חם$/ }));
+    // And flip a boolean requirement — "מעלית חובה".
+    await user.click(screen.getByRole('button', { name: /מעלית/ }));
+    // Submit.
+    await user.click(screen.getByRole('button', { name: /החל סינון/ }));
+    expect(onApply).toHaveBeenCalled();
+    const next = onApply.mock.calls[0][0];
+    expect(next.heat).toEqual(['HOT']);
+    expect(next.elevatorRequired).toBe(true);
+  });
+
+  it('pre-fills selected chips from the `filters` prop', () => {
+    render(
+      <CustomerFiltersPanel
+        {...baseProps({
+          filters: {
+            heat: ['WARM'],
+            leadStatus: ['NEW'],
+            parkingRequired: true,
+          },
+        })}
+      />
+    );
+    // Buttons for selected chips should carry aria-pressed=true. Using
+    // getByRole('button', {pressed: true}) returns only the selected set.
+    const pressed = screen.getAllByRole('button', { pressed: true });
+    const pressedLabels = pressed.map((b) => b.textContent?.trim());
+    expect(pressedLabels).toEqual(expect.arrayContaining(['חמים', 'חדש', 'חניה']));
+  });
+
+  it('clears all filters and re-applies when "נקה" is clicked', async () => {
+    const user = userEvent.setup({ delay: null });
+    const onApply = vi.fn();
+    render(
+      <CustomerFiltersPanel
+        {...baseProps({
+          filters: { heat: ['HOT'], parkingRequired: true },
+          onApply,
+        })}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /^נקה/ }));
+    await user.click(screen.getByRole('button', { name: /החל סינון/ }));
+    const next = onApply.mock.calls[onApply.mock.calls.length - 1][0];
+    expect(next.heat).toBeUndefined();
+    expect(next.parkingRequired).toBeUndefined();
+  });
+
+  it('loads the tag library and lets the agent tick tags', async () => {
+    const user = userEvent.setup({ delay: null });
+    server.use(
+      http.get('/api/tags', () =>
+        HttpResponse.json({
+          items: [
+            { id: 't1', name: 'VIP',  color: 'red',  scope: 'LEAD' },
+            { id: 't2', name: 'חדש', color: 'blue', scope: 'ALL' },
+          ],
+        })
+      )
+    );
+    const onApply = vi.fn();
+    render(<CustomerFiltersPanel {...baseProps({ onApply })} />);
+    // The tag chips render async after the /api/tags fetch.
+    const tagChip = await screen.findByRole('button', { name: /^VIP$/ });
+    await user.click(tagChip);
+    await user.click(screen.getByRole('button', { name: /החל סינון/ }));
+    const next = onApply.mock.calls[0][0];
+    expect(next.tags).toEqual(['t1']);
+  });
+
+  it('captures a price range and an elevator requirement together', async () => {
+    const user = userEvent.setup({ delay: null });
+    const onApply = vi.fn();
+    render(<CustomerFiltersPanel {...baseProps({ onApply })} />);
+    // The NumberField exposes itself as a textbox.
+    const minInput = screen.getByLabelText('תקציב מינימום');
+    const maxInput = screen.getByLabelText('תקציב מקסימום');
+    await user.type(minInput, '1000000');
+    await user.type(maxInput, '2500000');
+    await user.click(screen.getByRole('button', { name: /מעלית/ }));
+    await user.click(screen.getByRole('button', { name: /החל סינון/ }));
+    const next = onApply.mock.calls[0][0];
+    expect(next.minPrice).toBe(1000000);
+    expect(next.maxPrice).toBe(2500000);
+    expect(next.elevatorRequired).toBe(true);
+  });
+});

--- a/tests/frontend/components/composites/CustomerFiltersPanel.test.tsx
+++ b/tests/frontend/components/composites/CustomerFiltersPanel.test.tsx
@@ -122,6 +122,44 @@ describe('<CustomerFiltersPanel>', () => {
     expect(next.tags).toEqual(['t1']);
   });
 
+  it('disables the neighborhood picker when no city is set', () => {
+    render(<CustomerFiltersPanel {...baseProps()} />);
+    // The neighborhood picker renders in disabled mode with a Hebrew
+    // prompt telling the agent to pick a city first.
+    const nbhInput = screen.getByRole('combobox', { name: /שכונות/ });
+    expect(nbhInput).toBeDisabled();
+    expect(nbhInput).toHaveAttribute('placeholder', expect.stringContaining('עיר'));
+  });
+
+  it('enables the neighborhood picker and commits picks when a city is selected', async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.get('/api/neighborhoods', () =>
+        HttpResponse.json({
+          items: [{ id: 'n1', city: 'תל אביב', name: 'פלורנטין', aliases: [] }],
+        })
+      )
+    );
+    const onApply = vi.fn();
+    render(
+      <CustomerFiltersPanel
+        {...baseProps({ filters: { cities: ['תל אביב'] }, onApply })}
+      />
+    );
+    const nbhInput = screen.getByRole('combobox', { name: /שכונות/ });
+    expect(nbhInput).not.toBeDisabled();
+    await user.type(nbhInput, 'פלו');
+    const option = await screen.findByRole(
+      'option',
+      { name: /פלורנטין/ },
+      { timeout: 2000 },
+    );
+    await user.click(option);
+    await user.click(screen.getByRole('button', { name: /החל סינון/ }));
+    const next = onApply.mock.calls[0][0];
+    expect(next.neighborhoods).toEqual(['פלורנטין']);
+  });
+
   it('captures a price range and an elevator requirement together', async () => {
     const user = userEvent.setup({ delay: null });
     const onApply = vi.fn();

--- a/tests/frontend/components/composites/LeadSearchProfilesEditor.test.tsx
+++ b/tests/frontend/components/composites/LeadSearchProfilesEditor.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { render, screen, userEvent, waitFor } from '../../setup/test-utils';
+import { server } from '../../setup/msw-server';
+import LeadSearchProfilesEditor from '@estia/frontend/components/LeadSearchProfilesEditor.jsx';
+
+// Focus of this file is the MLS G1 wiring: the profile's neighborhoods
+// field is now a NeighborhoodPicker keyed off the first city in
+// profile.cities. Without a city, the picker sits disabled; once a city
+// is populated (via the parent form restoring a saved profile), the
+// picker enables and suggestions flow from /api/neighborhoods.
+
+beforeEach(() => {
+  // Default handlers: one profile with a city populated so the picker
+  // activates. Tests override as needed.
+  server.use(
+    http.get('/api/leads/:leadId/search-profiles', () =>
+      HttpResponse.json({
+        items: [
+          {
+            id: 'sp1',
+            label: 'חיפוש גבעתיים',
+            domain: 'RESIDENTIAL',
+            dealType: 'SALE',
+            cities: ['גבעתיים'],
+            neighborhoods: [],
+            propertyTypes: [],
+          },
+        ],
+      })
+    ),
+  );
+});
+
+describe('<LeadSearchProfilesEditor> neighborhood picker wiring', () => {
+  it('renders the NeighborhoodPicker scoped to the first city on the profile', async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.get('/api/neighborhoods', ({ request }) => {
+        const url = new URL(request.url);
+        expect(url.searchParams.get('city')).toBe('גבעתיים');
+        return HttpResponse.json({
+          items: [{ id: 'n1', city: 'גבעתיים', name: 'ותיקים', aliases: [] }],
+        });
+      }),
+    );
+    render(<LeadSearchProfilesEditor leadId="L1" />);
+    // Expand the first profile row.
+    const toggle = await screen.findByRole('button', { expanded: false });
+    await user.click(toggle);
+    // The neighborhood picker input carries an aria-label "שכונות".
+    const nbhInput = await screen.findByRole('combobox', { name: /שכונות/ });
+    expect(nbhInput).not.toBeDisabled();
+    await user.type(nbhInput, 'ות');
+    const option = await screen.findByRole('option', { name: /ותיקים/ });
+    await user.click(option);
+    // The chip renders after selection.
+    await waitFor(() => {
+      expect(screen.getByText('ותיקים')).toBeInTheDocument();
+    });
+  });
+
+  it('disables the picker when the profile has no city', async () => {
+    server.use(
+      http.get('/api/leads/:leadId/search-profiles', () =>
+        HttpResponse.json({
+          items: [
+            {
+              id: 'sp2',
+              label: 'ללא עיר',
+              cities: [],
+              neighborhoods: [],
+              propertyTypes: [],
+            },
+          ],
+        })
+      ),
+    );
+    const user = userEvent.setup();
+    render(<LeadSearchProfilesEditor leadId="L1" />);
+    const toggle = await screen.findByRole('button', { expanded: false });
+    await user.click(toggle);
+    const nbhInput = await screen.findByRole('combobox', { name: /שכונות/ });
+    expect(nbhInput).toBeDisabled();
+  });
+});

--- a/tests/frontend/components/composites/NeighborhoodPicker.test.tsx
+++ b/tests/frontend/components/composites/NeighborhoodPicker.test.tsx
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi } from 'vitest';
+import { useState } from 'react';
+import { http, HttpResponse } from 'msw';
+import { axe } from 'vitest-axe';
+import { render, screen, userEvent, waitFor } from '../../setup/test-utils';
+import { server } from '../../setup/msw-server';
+import NeighborhoodPicker from '@estia/frontend/components/NeighborhoodPicker.jsx';
+
+// Stateful harness so we can assert onChange in isolation while still
+// letting the picker re-render with its new `value` on each mutation.
+function Harness({
+  city,
+  initial = [],
+  onChange,
+  placeholder,
+}: {
+  city: string;
+  initial?: string[];
+  onChange?: (v: string[]) => void;
+  placeholder?: string;
+}) {
+  const [value, setValue] = useState<string[]>(initial);
+  return (
+    <NeighborhoodPicker
+      city={city}
+      value={value}
+      onChange={(next: string[]) => { setValue(next); onChange?.(next); }}
+      placeholder={placeholder}
+    />
+  );
+}
+
+describe('<NeighborhoodPicker>', () => {
+  it('disables the input and shows a prompt when no city is set', () => {
+    render(<NeighborhoodPicker city="" value={[]} onChange={() => {}} />);
+    const input = screen.getByRole('combobox');
+    expect(input).toBeDisabled();
+    // The prompt copy is Hebrew — "בחר עיר תחילה".
+    expect(input).toHaveAttribute('placeholder', expect.stringContaining('עיר'));
+  });
+
+  it('shows suggestions after typing and inserts a chip on select', async () => {
+    server.use(
+      http.get('/api/neighborhoods', () =>
+        HttpResponse.json({
+          items: [
+            { id: 'n1', city: 'תל אביב', name: 'פלורנטין', aliases: [] },
+            { id: 'n2', city: 'תל אביב', name: 'לב העיר',  aliases: [] },
+          ],
+        })
+      ),
+    );
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Harness city="תל אביב" onChange={onChange} />);
+    const input = screen.getByRole('combobox');
+    await user.type(input, 'פלו');
+    // Suggestions appear (debounced 200ms).
+    const option = await screen.findByRole('option', { name: /פלורנטין/ }, { timeout: 2000 });
+    await user.click(option);
+    expect(onChange).toHaveBeenLastCalledWith(['פלורנטין']);
+    // The chip renders the selected value.
+    expect(screen.getByText('פלורנטין')).toBeInTheDocument();
+  });
+
+  it('supports multi-select — accumulates chips and prevents duplicates', async () => {
+    server.use(
+      http.get('/api/neighborhoods', ({ request }) => {
+        const url = new URL(request.url);
+        const s = url.searchParams.get('search') || '';
+        const catalog = [
+          { id: 'n1', city: 'תל אביב', name: 'פלורנטין', aliases: [] },
+          { id: 'n2', city: 'תל אביב', name: 'לב העיר', aliases: [] },
+          { id: 'n3', city: 'תל אביב', name: 'נווה צדק', aliases: [] },
+        ];
+        return HttpResponse.json({
+          items: catalog.filter((x) => !s || x.name.includes(s)),
+        });
+      }),
+    );
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Harness city="תל אביב" onChange={onChange} />);
+    const input = screen.getByRole('combobox');
+
+    await user.type(input, 'פלו');
+    const florentin = await screen.findByRole('option', { name: /פלורנטין/ });
+    await user.click(florentin);
+
+    // Clear + type for the second selection.
+    await user.clear(input);
+    await user.type(input, 'נווה');
+    const neve = await screen.findByRole('option', { name: /נווה צדק/ });
+    await user.click(neve);
+
+    expect(onChange).toHaveBeenLastCalledWith(['פלורנטין', 'נווה צדק']);
+    expect(screen.getByText('פלורנטין')).toBeInTheDocument();
+    expect(screen.getByText('נווה צדק')).toBeInTheDocument();
+
+    // Already-picked values must not re-appear in the suggestions list.
+    await user.clear(input);
+    await user.type(input, 'פלו');
+    // After the debounce settles, no option should be offered for
+    // פלורנטין because it's already selected.
+    await waitFor(() => {
+      expect(screen.queryByRole('option', { name: /פלורנטין/ })).toBeNull();
+    });
+    // And the current selection should still contain exactly one of it.
+    const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
+    expect(lastCall.filter((x: string) => x === 'פלורנטין')).toHaveLength(1);
+  });
+
+  it('removes a chip when the remove button is clicked', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <Harness
+        city="תל אביב"
+        initial={['פלורנטין', 'לב העיר']}
+        onChange={onChange}
+      />
+    );
+    const removeBtn = screen.getByRole('button', { name: /הסר.*פלורנטין/ });
+    await user.click(removeBtn);
+    expect(onChange).toHaveBeenLastCalledWith(['לב העיר']);
+  });
+
+  it('falls back to adding free-text on Enter when the user bypasses suggestions', async () => {
+    // If the agent types a neighborhood that isn't in our catalog, hitting
+    // Enter should still accept it. Prevents the picker from being a gate.
+    server.use(
+      http.get('/api/neighborhoods', () => HttpResponse.json({ items: [] })),
+    );
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Harness city="תל אביב" onChange={onChange} />);
+    const input = screen.getByRole('combobox');
+    await user.type(input, 'שכונה חדשה');
+    // Wait for debounce to settle and the empty result to render.
+    await waitFor(() => {
+      expect(input).toHaveValue('שכונה חדשה');
+    });
+    await user.keyboard('{Enter}');
+    expect(onChange).toHaveBeenLastCalledWith(['שכונה חדשה']);
+  });
+
+  it('has no accessibility violations on initial render', async () => {
+    const { container } = render(
+      <NeighborhoodPicker
+        city="תל אביב"
+        value={['פלורנטין']}
+        onChange={() => {}}
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/tests/frontend/components/composites/PropertyAssigneesPanel.test.tsx
+++ b/tests/frontend/components/composites/PropertyAssigneesPanel.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { axe } from 'vitest-axe';
+import { render, screen, userEvent, waitFor } from '../../setup/test-utils';
+import { server } from '../../setup/msw-server';
+import PropertyAssigneesPanel from '@estia/frontend/components/PropertyAssigneesPanel.jsx';
+
+describe('<PropertyAssigneesPanel>', () => {
+  it('renders the EmptyState when the property has no assignees', async () => {
+    render(<PropertyAssigneesPanel propertyId="p1" />);
+    await waitFor(() => expect(screen.getByText('אין שותפים משויכים')).toBeInTheDocument());
+  });
+
+  it('renders the list of existing assignees + their role label', async () => {
+    server.use(
+      http.get('/api/properties/:id/assignees', () =>
+        HttpResponse.json({
+          items: [
+            {
+              userId: 'u2', role: 'CO_AGENT',
+              user: { id: 'u2', displayName: 'שותפה', email: 'partner@estia.app', role: 'AGENT' },
+            },
+            {
+              userId: 'u3', role: 'OBSERVER',
+              user: { id: 'u3', displayName: 'צופה', email: 'obs@estia.app', role: 'AGENT' },
+            },
+          ],
+        })
+      )
+    );
+    render(<PropertyAssigneesPanel propertyId="p1" />);
+    await waitFor(() => expect(screen.getByText('שותפה')).toBeInTheDocument());
+    // Both role labels appear in the rendered list. "שותף" and "צופה"
+    // also appear as <option>s inside the add form — getAllByText is
+    // the safe cross-source match.
+    expect(screen.getAllByText('צופה').length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText('שותף').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('resolves email → userId then POSTs with the chosen role', async () => {
+    const user = userEvent.setup();
+    let postBody: unknown = null;
+    server.use(
+      http.get('/api/transfers/agents/search', () =>
+        HttpResponse.json({
+          agent: {
+            id: 'u9', email: 'x@estia.app',
+            displayName: 'איקס', phone: null, avatarUrl: null, agency: null,
+          },
+        })
+      ),
+      http.post('/api/properties/:id/assignees', async ({ request }) => {
+        postBody = await request.json();
+        return HttpResponse.json({ assignee: { propertyId: 'p1', userId: 'u9', role: 'OBSERVER' } });
+      })
+    );
+    render(<PropertyAssigneesPanel propertyId="p1" />);
+    await waitFor(() => expect(screen.getByText('אין שותפים משויכים')).toBeInTheDocument());
+    await user.type(screen.getByLabelText('אימייל שותף'), 'x@estia.app');
+    await user.selectOptions(screen.getByLabelText('תפקיד השותף'), 'OBSERVER');
+    await user.click(screen.getByRole('button', { name: /הוסף שותף/ }));
+    await waitFor(() => expect(postBody).toBeTruthy());
+    expect(postBody).toMatchObject({ userId: 'u9', role: 'OBSERVER' });
+  });
+
+  it('surfaces Hebrew error when the email is not found', async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.get('/api/transfers/agents/search', () => HttpResponse.json({ agent: null }))
+    );
+    const errs: string[] = [];
+    const toast = { success: () => {}, info: () => {}, error: (m: string) => { errs.push(m); } };
+    render(<PropertyAssigneesPanel propertyId="p1" toast={toast} />);
+    await waitFor(() => expect(screen.getByText('אין שותפים משויכים')).toBeInTheDocument());
+    await user.type(screen.getByLabelText('אימייל שותף'), 'nope@estia.app');
+    await user.click(screen.getByRole('button', { name: /הוסף שותף/ }));
+    await waitFor(() => expect(errs.length).toBeGreaterThan(0));
+    expect(errs[0]).toMatch(/לא נמצא/);
+  });
+
+  it('removes an assignee when clicking the per-row remove button', async () => {
+    const user = userEvent.setup();
+    let removedId: string | null = null;
+    server.use(
+      http.get('/api/properties/:id/assignees', () =>
+        HttpResponse.json({
+          items: [{
+            userId: 'u2', role: 'CO_AGENT',
+            user: { id: 'u2', displayName: 'שותפה', email: 'p@estia.app', role: 'AGENT' },
+          }],
+        })
+      ),
+      http.delete('/api/properties/:id/assignees/:userId', ({ params }) => {
+        removedId = params.userId as string;
+        return HttpResponse.json({ ok: true });
+      })
+    );
+    render(<PropertyAssigneesPanel propertyId="p1" />);
+    await waitFor(() => expect(screen.getByText('שותפה')).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: /הסר את שותפה/ }));
+    await waitFor(() => expect(removedId).toBe('u2'));
+  });
+
+  it('has no axe violations', async () => {
+    const { baseElement } = render(<PropertyAssigneesPanel propertyId="p1" />);
+    await waitFor(() => expect(screen.getByText('אין שותפים משויכים')).toBeInTheDocument());
+    expect(await axe(baseElement)).toHaveNoViolations();
+  });
+});

--- a/tests/frontend/components/composites/PropertyPipelineBlock.test.tsx
+++ b/tests/frontend/components/composites/PropertyPipelineBlock.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { axe } from 'vitest-axe';
+import { render, screen, userEvent, waitFor } from '../../setup/test-utils';
+import { server } from '../../setup/msw-server';
+import PropertyPipelineBlock from '@estia/frontend/components/PropertyPipelineBlock.jsx';
+
+describe('<PropertyPipelineBlock>', () => {
+  it('renders the Hebrew stage + seriousness labels', () => {
+    render(<PropertyPipelineBlock property={{ id: 'p1', stage: 'IN_PROGRESS', sellerSeriousness: 'VERY' }} />);
+    const stage = screen.getByLabelText('שלב הנכס') as HTMLSelectElement;
+    expect(stage.value).toBe('IN_PROGRESS');
+    // Segmented/select labels from the mlsLabels map should render.
+    expect(screen.getByRole('option', { name: 'בתהליך' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'חתום — בלעדי' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'מאוד' })).toBeInTheDocument();
+  });
+
+  it('controlled mode calls onChange for every field, never saves', async () => {
+    const user = userEvent.setup();
+    const changes: Array<[string, unknown]> = [];
+    const form = {
+      stage: 'WATCHING',
+      agentCommissionPct: null,
+      primaryAgentId: null,
+      exclusivityExpire: '',
+      sellerSeriousness: 'NONE',
+      brokerNotes: '',
+    };
+    render(<PropertyPipelineBlock form={form} onChange={(k, v) => changes.push([k, v])} />);
+    // No save button in controlled mode.
+    expect(screen.queryByRole('button', { name: 'שמור' })).not.toBeInTheDocument();
+    await user.selectOptions(screen.getByLabelText('שלב הנכס'), 'SIGNED_EXCLUSIVE');
+    expect(changes.at(-1)).toEqual(['stage', 'SIGNED_EXCLUSIVE']);
+    await user.type(screen.getByLabelText('הערות מתווך'), 'a');
+    expect(changes.find(([k]) => k === 'brokerNotes')?.[1]).toBe('a');
+  });
+
+  it('inline edit mode saves via api.updateProperty on button click', async () => {
+    const user = userEvent.setup();
+    let patchBody: unknown = null;
+    server.use(
+      http.patch('/api/properties/:id', async ({ request }) => {
+        patchBody = await request.json();
+        return HttpResponse.json({ property: { id: 'p1' } });
+      })
+    );
+    let savedCalled = 0;
+    render(
+      <PropertyPipelineBlock
+        property={{ id: 'p1', stage: 'IN_PROGRESS', agentCommissionPct: 2.5, brokerNotes: 'hi', sellerSeriousness: 'MEDIUM' }}
+        onSaved={() => { savedCalled += 1; }}
+      />
+    );
+    await user.selectOptions(screen.getByLabelText('שלב הנכס'), 'SIGNED_EXCLUSIVE');
+    await user.click(screen.getByRole('button', { name: 'שמור' }));
+    await waitFor(() => expect(patchBody).toBeTruthy());
+    expect((patchBody as { stage: string }).stage).toBe('SIGNED_EXCLUSIVE');
+    expect((patchBody as { sellerSeriousness: string }).sellerSeriousness).toBe('MEDIUM');
+    await waitFor(() => expect(savedCalled).toBe(1));
+  });
+
+  it('looks up primary agent by email and shows the matched agent', async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.get('/api/transfers/agents/search', () =>
+        HttpResponse.json({
+          agent: {
+            id: 'u2', email: 'partner@estia.app',
+            displayName: 'שותף', phone: null, avatarUrl: null, agency: null,
+          },
+        })
+      )
+    );
+    render(<PropertyPipelineBlock property={{ id: 'p1' }} />);
+    const emailInput = screen.getByLabelText('אימייל של הסוכן הראשי');
+    await user.type(emailInput, 'partner@estia.app');
+    await user.click(screen.getByRole('button', { name: 'חפש' }));
+    await waitFor(() => expect(screen.getByText('שותף')).toBeInTheDocument());
+  });
+
+  it('renders without axe violations', async () => {
+    const { baseElement } = render(
+      <PropertyPipelineBlock property={{ id: 'p1', stage: 'WATCHING' }} />
+    );
+    expect(await axe(baseElement)).toHaveNoViolations();
+  });
+});

--- a/tests/frontend/components/composites/SavedSearchMenu.test.tsx
+++ b/tests/frontend/components/composites/SavedSearchMenu.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { render, screen, userEvent, waitFor } from '../../setup/test-utils';
+import { server } from '../../setup/msw-server';
+import SavedSearchMenu from '@estia/frontend/components/SavedSearchMenu.jsx';
+
+const exampleSaved = [
+  {
+    id: 'ss-1', entityType: 'LEAD', name: 'קונים בתל אביב',
+    filters: { cities: ['תל אביב'], lookingFor: 'BUY' },
+    createdAt: '2026-04-10T00:00:00.000Z',
+  },
+  {
+    id: 'ss-2', entityType: 'LEAD', name: 'דחוף',
+    filters: { seriousness: ['VERY'] },
+    createdAt: '2026-04-12T00:00:00.000Z',
+  },
+];
+
+function renderMenu(overrides: Partial<React.ComponentProps<typeof SavedSearchMenu>> = {}) {
+  const props = {
+    entityType: 'LEAD' as const,
+    currentFilters: { cities: ['רמת גן'] },
+    onLoad: vi.fn(),
+    ...overrides,
+  };
+  render(<SavedSearchMenu {...props} />);
+  return props;
+}
+
+describe('<SavedSearchMenu>', () => {
+  it('renders a closed trigger button labelled "חיפושים שמורים"', () => {
+    renderMenu();
+    expect(screen.getByRole('button', { name: /חיפושים שמורים/ })).toBeInTheDocument();
+  });
+
+  it('opens the dropdown on click and fetches the list', async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.get('/api/saved-searches', () =>
+        HttpResponse.json({ items: exampleSaved })
+      )
+    );
+    renderMenu();
+    await user.click(screen.getByRole('button', { name: /חיפושים שמורים/ }));
+    expect(await screen.findByText('קונים בתל אביב')).toBeInTheDocument();
+    expect(screen.getByText('דחוף')).toBeInTheDocument();
+  });
+
+  it('shows an empty hint when nothing is saved yet', async () => {
+    const user = userEvent.setup();
+    renderMenu();
+    await user.click(screen.getByRole('button', { name: /חיפושים שמורים/ }));
+    expect(await screen.findByText(/אין עדיין חיפושים שמורים/)).toBeInTheDocument();
+  });
+
+  it('loads a search via onLoad when an item is clicked', async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.get('/api/saved-searches', () =>
+        HttpResponse.json({ items: exampleSaved })
+      )
+    );
+    const props = renderMenu();
+    await user.click(screen.getByRole('button', { name: /חיפושים שמורים/ }));
+    await user.click(await screen.findByText('קונים בתל אביב'));
+    expect(props.onLoad).toHaveBeenCalledWith(
+      expect.objectContaining({ cities: ['תל אביב'], lookingFor: 'BUY' })
+    );
+  });
+
+  it('saves the current filters under a name via POST /saved-searches', async () => {
+    const user = userEvent.setup();
+    let captured: any = null;
+    server.use(
+      http.get('/api/saved-searches', () => HttpResponse.json({ items: [] })),
+      http.post('/api/saved-searches', async ({ request }) => {
+        captured = await request.json();
+        return HttpResponse.json({
+          savedSearch: { id: 'ss-new', ...captured },
+        });
+      })
+    );
+    const props = renderMenu({ currentFilters: { cities: ['חיפה'], minPrice: 1000000 } });
+    await user.click(screen.getByRole('button', { name: /חיפושים שמורים/ }));
+    const input = await screen.findByPlaceholderText(/שם לחיפוש/);
+    await user.type(input, 'חיפה זול');
+    await user.click(screen.getByRole('button', { name: /^שמור$/ }));
+    await waitFor(() => expect(captured).not.toBeNull());
+    expect(captured).toMatchObject({
+      entityType: 'LEAD',
+      name: 'חיפה זול',
+      filters: { cities: ['חיפה'], minPrice: 1000000 },
+    });
+    // The new entry should appear in the list after save.
+    expect(await screen.findByText('חיפה זול')).toBeInTheDocument();
+  });
+
+  it('deletes a saved search via the trash button', async () => {
+    const user = userEvent.setup();
+    let deleted = false;
+    server.use(
+      http.get('/api/saved-searches', () =>
+        HttpResponse.json({ items: exampleSaved })
+      ),
+      http.delete('/api/saved-searches/ss-2', () => {
+        deleted = true;
+        return HttpResponse.json({ ok: true });
+      })
+    );
+    renderMenu();
+    await user.click(screen.getByRole('button', { name: /חיפושים שמורים/ }));
+    await screen.findByText('דחוף');
+    // Each row has a trash button with aria-label "מחק <name>".
+    await user.click(screen.getByRole('button', { name: /מחק דחוף/ }));
+    await waitFor(() => expect(deleted).toBe(true));
+    // The row should be removed from the list.
+    await waitFor(() => expect(screen.queryByText('דחוף')).toBeNull());
+  });
+
+  it('filters the list by the entityType prop', async () => {
+    const user = userEvent.setup();
+    const capture = vi.fn();
+    server.use(
+      http.get('/api/saved-searches', ({ request }) => {
+        const url = new URL(request.url);
+        capture(url.searchParams.get('entityType'));
+        return HttpResponse.json({ items: [] });
+      })
+    );
+    renderMenu({ entityType: 'LEAD' });
+    await user.click(screen.getByRole('button', { name: /חיפושים שמורים/ }));
+    await waitFor(() => expect(capture).toHaveBeenCalledWith('LEAD'));
+  });
+});

--- a/tests/frontend/components/features/ActivityPanel.test.tsx
+++ b/tests/frontend/components/features/ActivityPanel.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { render, screen } from '../../setup/test-utils';
+import { server } from '../../setup/msw-server';
+import ActivityPanel from '@estia/frontend/components/ActivityPanel.jsx';
+
+describe('<ActivityPanel>', () => {
+  it('renders the empty state when no events exist', async () => {
+    server.use(http.get('/api/activity', () => HttpResponse.json({ items: [] })));
+    render(<ActivityPanel entityType="Lead" entityId="lead-1" />);
+    expect(await screen.findByText('אין פעילות עדיין')).toBeInTheDocument();
+  });
+
+  it('lists events with the actor + summary', async () => {
+    server.use(
+      http.get('/api/activity', () =>
+        HttpResponse.json({
+          items: [
+            {
+              id: 'a1',
+              kind: 'STATUS_CHANGE',
+              action: 'עודכן סטטוס',
+              actorName: 'יוסי כהן',
+              summary: 'הסטטוס שונה ל״חם״',
+              createdAt: new Date().toISOString(),
+            },
+            {
+              id: 'a2',
+              kind: 'NOTE_ADDED',
+              action: 'הוספה הערה',
+              actorName: 'מיכל',
+              summary: 'הוספה הערה על פגישה',
+              createdAt: new Date().toISOString(),
+            },
+          ],
+        })
+      )
+    );
+    render(<ActivityPanel entityType="Lead" entityId="lead-1" />);
+    expect(await screen.findByText('הסטטוס שונה ל״חם״')).toBeInTheDocument();
+    expect(screen.getByText('הוספה הערה על פגישה')).toBeInTheDocument();
+    expect(screen.getByText('יוסי כהן')).toBeInTheDocument();
+  });
+
+  it('shows the error banner on a failed fetch', async () => {
+    server.use(
+      http.get('/api/activity', () =>
+        HttpResponse.json({ error: { message: 'bad' } }, { status: 500 })
+      )
+    );
+    render(<ActivityPanel entityType="Lead" entityId="lead-1" />);
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+  });
+});

--- a/tests/frontend/components/features/Layout.test.tsx
+++ b/tests/frontend/components/features/Layout.test.tsx
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, userEvent } from '../../setup/test-utils';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../setup/msw-server';
+import { render, screen, userEvent, waitFor } from '../../setup/test-utils';
 import Layout from '@estia/frontend/components/Layout.jsx';
 
 describe('<Layout>', () => {
@@ -30,5 +32,83 @@ describe('<Layout>', () => {
     // After click, the label flips to "הרחב" because collapsed = true.
     expect(screen.getByRole('button', { name: /הרחב סרגל/ })).toBeInTheDocument();
     expect(localStorage.getItem('estia-sidebar-collapsed')).toBe('1');
+  });
+
+  // ─── Sprint 4 + Sprint 1 A2 sidebar entries ─────────────────────────
+  it('renders the "כלי ניהול" nav group with reports / activity / reminders / tag-settings links', () => {
+    render(<Layout onLogout={() => {}} />);
+    // Group label visible at least once (desktop sidebar).
+    expect(screen.getAllByText('כלי ניהול').length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('link', { name: /דוחות/ }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('link', { name: /פעילות/ }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('link', { name: /תזכורות/ }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('link', { name: /תגיות/ }).length).toBeGreaterThan(0);
+  });
+
+  it('does NOT render the Office link for AGENT role', async () => {
+    render(<Layout onLogout={() => {}} />);
+    // Wait a tick so any async /api/me has had a chance to settle; the
+    // demo user in the default MSW handlers is role=AGENT.
+    await waitFor(() => {
+      expect(screen.queryByRole('link', { name: /משרד/ })).toBeNull();
+    });
+  });
+
+  it('renders the Office link for OWNER role', async () => {
+    server.use(
+      http.get('/api/me', () =>
+        HttpResponse.json({
+          user: {
+            id: 'test-owner-1',
+            email: 'owner@estia.app',
+            role: 'OWNER',
+            displayName: 'בעל משרד',
+            agentProfile: { agency: 'Acme', title: '', bio: '' },
+          },
+        })
+      )
+    );
+    render(<Layout onLogout={() => {}} />);
+    await waitFor(() => {
+      expect(screen.getAllByRole('link', { name: /משרד/ }).length).toBeGreaterThan(0);
+    });
+  });
+
+  // ─── Sprint 7 B4 favorites strip ────────────────────────────────────
+  it('renders the favorites strip when the user has favorited entities', async () => {
+    server.use(
+      http.get('/api/favorites', () =>
+        HttpResponse.json({
+          items: [
+            { entityType: 'PROPERTY', entityId: 'p-fav-1', createdAt: new Date().toISOString() },
+          ],
+        })
+      ),
+      http.get('/api/properties', () =>
+        HttpResponse.json({
+          items: [
+            { id: 'p-fav-1', street: 'רוטשילד', number: '12', city: 'תל אביב', type: 'APARTMENT' },
+          ],
+        })
+      )
+    );
+    render(<Layout onLogout={() => {}} />);
+    await waitFor(() => {
+      expect(screen.getAllByText('המועדפים').length).toBeGreaterThan(0);
+    });
+    // The favorite should link to its detail page
+    await waitFor(() => {
+      const links = screen.getAllByRole('link', { name: /רוטשילד/ });
+      expect(links.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('hides the favorites strip entirely when the list is empty', async () => {
+    // The default MSW handler returns an empty items list — no "המועדפים"
+    // label should appear. We wait a tick so the fetch has had its turn.
+    render(<Layout onLogout={() => {}} />);
+    await waitFor(() => {
+      expect(screen.queryByText('המועדפים')).toBeNull();
+    });
   });
 });

--- a/tests/frontend/components/features/LeadSearchProfilesEditor.test.tsx
+++ b/tests/frontend/components/features/LeadSearchProfilesEditor.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { render, screen, userEvent, waitFor } from '../../setup/test-utils';
+import { server } from '../../setup/msw-server';
+import LeadSearchProfilesEditor from '@estia/frontend/components/LeadSearchProfilesEditor.jsx';
+
+const PROFILE = {
+  id: 'sp-1',
+  label: 'גבעתיים 4ח׳',
+  domain: 'RESIDENTIAL',
+  dealType: 'SALE',
+  propertyTypes: [],
+  cities: ['גבעתיים'],
+  neighborhoods: [],
+  streets: [],
+  minRoom: 3,
+  maxRoom: 5,
+  minPrice: 2_000_000,
+  maxPrice: 3_500_000,
+  minFloor: null, maxFloor: null, minBuilt: null, maxBuilt: null,
+  parkingReq: true,
+  elevatorReq: false,
+  balconyReq: false,
+  furnitureReq: false,
+  mamadReq: false,
+  storeroomReq: false,
+};
+
+describe('<LeadSearchProfilesEditor>', () => {
+  it('renders the empty state when no profiles exist', async () => {
+    server.use(
+      http.get('/api/leads/:leadId/search-profiles', () => HttpResponse.json({ items: [] }))
+    );
+    render(<LeadSearchProfilesEditor leadId="lead-1" />);
+    expect(await screen.findByText('אין עדיין פרופילי חיפוש')).toBeInTheDocument();
+  });
+
+  it('creates a new profile via the "פרופיל חדש" button', async () => {
+    const user = userEvent.setup();
+    let createdBody: { label?: string } = {};
+    server.use(
+      http.get('/api/leads/:leadId/search-profiles', () => HttpResponse.json({ items: [] })),
+      http.post('/api/leads/:leadId/search-profiles', async ({ request }) => {
+        createdBody = (await request.json()) as { label?: string };
+        return HttpResponse.json({
+          profile: { id: 'sp-new', label: createdBody.label, cities: [], neighborhoods: [] },
+        });
+      }),
+    );
+    render(<LeadSearchProfilesEditor leadId="lead-1" />);
+    await screen.findByText('אין עדיין פרופילי חיפוש');
+    await user.click(screen.getByRole('button', { name: /פרופיל חדש/ }));
+    await waitFor(() => expect(createdBody.label).toBe('חיפוש חדש'));
+    // New row is rendered with the default label.
+    await screen.findByDisplayValue('חיפוש חדש');
+  });
+
+  it('lists existing profiles with their label and expands body on click', async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.get('/api/leads/:leadId/search-profiles', () =>
+        HttpResponse.json({ items: [PROFILE] })
+      )
+    );
+    render(<LeadSearchProfilesEditor leadId="lead-1" />);
+    await screen.findByDisplayValue('גבעתיים 4ח׳');
+    // Body fields aren't rendered until the row is expanded.
+    expect(screen.queryByLabelText('ערים')).toBeNull();
+    await user.click(screen.getByRole('button', { expanded: false }));
+    expect(await screen.findByLabelText('ערים')).toBeInTheDocument();
+  });
+
+  it('saves local edits via PATCH on שמור', async () => {
+    const user = userEvent.setup();
+    let patchBody: { label?: string } = {};
+    server.use(
+      http.get('/api/leads/:leadId/search-profiles', () =>
+        HttpResponse.json({ items: [PROFILE] })
+      ),
+      http.patch('/api/leads/:leadId/search-profiles/:id', async ({ request }) => {
+        patchBody = (await request.json()) as { label?: string };
+        return HttpResponse.json({ profile: { id: 'sp-1' } });
+      }),
+    );
+    render(<LeadSearchProfilesEditor leadId="lead-1" />);
+    const labelInput = await screen.findByDisplayValue('גבעתיים 4ח׳');
+    await user.clear(labelInput);
+    await user.type(labelInput, 'תל אביב');
+    await user.click(screen.getByRole('button', { name: /שמור פרופיל/ }));
+    await waitFor(() => expect(patchBody.label).toBe('תל אביב'));
+  });
+
+  it('deletes a profile via the trash button', async () => {
+    const user = userEvent.setup();
+    let deleted = false;
+    server.use(
+      http.get('/api/leads/:leadId/search-profiles', () =>
+        HttpResponse.json({ items: [PROFILE] })
+      ),
+      http.delete('/api/leads/:leadId/search-profiles/:id', () => {
+        deleted = true;
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+    render(<LeadSearchProfilesEditor leadId="lead-1" />);
+    await screen.findByDisplayValue('גבעתיים 4ח׳');
+    await user.click(screen.getByRole('button', { name: /מחק פרופיל/ }));
+    await waitFor(() => expect(deleted).toBe(true));
+  });
+});

--- a/tests/frontend/components/features/MatchingList.test.tsx
+++ b/tests/frontend/components/features/MatchingList.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { render, screen } from '../../setup/test-utils';
+import { server } from '../../setup/msw-server';
+import MatchingList from '@estia/frontend/components/MatchingList.jsx';
+
+describe('<MatchingList>', () => {
+  it('lists properties matching a lead with score + reasons', async () => {
+    server.use(
+      http.get('/api/leads/:id/matches', () =>
+        HttpResponse.json({
+          items: [
+            {
+              id: 'm1',
+              score: 84,
+              reasons: ['עיר תואמת', 'תקציב בטווח'],
+              property: { id: 'p1', title: 'דירת 4 חדרים בגבעתיים', price: 3_200_000 },
+            },
+          ],
+        })
+      )
+    );
+    render(<MatchingList leadId="lead-1" />);
+    expect(await screen.findByText('דירת 4 חדרים בגבעתיים')).toBeInTheDocument();
+    expect(screen.getByText('84')).toBeInTheDocument();
+    expect(screen.getByText('עיר תואמת')).toBeInTheDocument();
+    expect(screen.getByText('תקציב בטווח')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /דירת 4 חדרים בגבעתיים/ })).toHaveAttribute('href', '/properties/p1');
+  });
+
+  it('lists customers matching a property in reverse direction', async () => {
+    server.use(
+      http.get('/api/properties/:id/matching-customers', () =>
+        HttpResponse.json({
+          items: [
+            {
+              id: 'm2',
+              score: 62,
+              reasons: ['מחפש בעיר'],
+              lead: { id: 'lead-9', name: 'דני כהן', phone: '050-1111111' },
+            },
+          ],
+        })
+      )
+    );
+    render(<MatchingList propertyId="prop-1" />);
+    expect(await screen.findByText('דני כהן')).toBeInTheDocument();
+    expect(screen.getByText('62')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /דני כהן/ })).toHaveAttribute('href', '/customers/lead-9');
+  });
+
+  it('renders the empty state when no matches are returned', async () => {
+    server.use(http.get('/api/leads/:id/matches', () => HttpResponse.json({ items: [] })));
+    render(<MatchingList leadId="lead-1" />);
+    expect(await screen.findByText('אין התאמות כרגע')).toBeInTheDocument();
+  });
+
+  it('surfaces errors from the backend', async () => {
+    server.use(
+      http.get('/api/leads/:id/matches', () =>
+        HttpResponse.json({ error: { message: 'התאמות נפלו' } }, { status: 500 })
+      )
+    );
+    render(<MatchingList leadId="lead-1" />);
+    expect(await screen.findByRole('alert')).toHaveTextContent(/נכשלה|התאמות נפלו/);
+  });
+});

--- a/tests/frontend/components/features/MobileMoreSheet.test.tsx
+++ b/tests/frontend/components/features/MobileMoreSheet.test.tsx
@@ -1,0 +1,60 @@
+// MobileMoreSheet — the mobile "..." sheet. Desktop users see these
+// entry points in the sidebar; on iPhone they live here so the 5-slot
+// bottom tab bar doesn't get crowded.
+
+import { describe, it, expect, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../setup/msw-server';
+import { render, screen, userEvent, waitFor } from '../../setup/test-utils';
+import MobileMoreSheet from '@estia/frontend/components/MobileMoreSheet.jsx';
+
+describe('<MobileMoreSheet>', () => {
+  it('renders nothing when open=false', () => {
+    const { container } = render(<MobileMoreSheet open={false} onClose={() => {}} />);
+    expect(container.textContent || '').not.toMatch(/חיפוש מהיר/);
+  });
+
+  it('renders the Sprint 4 + Sprint 1 A2 entry points when open', () => {
+    render(<MobileMoreSheet open={true} onClose={() => {}} />);
+    // New entries from this commit. Each strong label is unique.
+    expect(screen.getByRole('button', { name: /דוחות/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /פעילות/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /תזכורות/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /ניהול תגיות/ })).toBeInTheDocument();
+  });
+
+  it('does NOT show the Office row for AGENT role', async () => {
+    render(<MobileMoreSheet open={true} onClose={() => {}} />);
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /המשרד שלי/ })).toBeNull();
+    });
+  });
+
+  it('shows the Office row for OWNER role', async () => {
+    server.use(
+      http.get('/api/me', () =>
+        HttpResponse.json({
+          user: {
+            id: 'test-owner-1',
+            email: 'owner@estia.app',
+            role: 'OWNER',
+            displayName: 'בעל משרד',
+            agentProfile: { agency: 'Acme', title: '', bio: '' },
+          },
+        })
+      )
+    );
+    render(<MobileMoreSheet open={true} onClose={() => {}} />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /המשרד שלי/ })).toBeInTheDocument();
+    });
+  });
+
+  it('clicking a new entry closes the sheet', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(<MobileMoreSheet open={true} onClose={onClose} />);
+    await user.click(screen.getByRole('button', { name: /דוחות/ }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/tests/frontend/components/features/RemindersPanel.test.tsx
+++ b/tests/frontend/components/features/RemindersPanel.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { render, screen, userEvent, waitFor } from '../../setup/test-utils';
+import { server } from '../../setup/msw-server';
+import RemindersPanel from '@estia/frontend/components/RemindersPanel.jsx';
+
+const BASE = [
+  {
+    id: 'r1',
+    title: 'להתקשר ללקוח',
+    dueAt: '2026-05-10T08:00:00.000Z',
+    notes: 'לבדוק אם לקח משכנתא',
+    status: 'PENDING',
+    leadId: 'lead-1',
+  },
+];
+
+describe('<RemindersPanel>', () => {
+  it('shows the empty state when there are no reminders', async () => {
+    server.use(http.get('/api/reminders', () => HttpResponse.json({ items: [] })));
+    render(<RemindersPanel leadId="lead-1" />);
+    await screen.findByText('אין תזכורות פתוחות');
+    expect(screen.getByRole('button', { name: /תזכורת חדשה/ })).toBeInTheDocument();
+  });
+
+  it('renders an existing reminder with its title + notes', async () => {
+    server.use(http.get('/api/reminders', () => HttpResponse.json({ items: BASE })));
+    render(<RemindersPanel leadId="lead-1" />);
+    expect(await screen.findByText('להתקשר ללקוח')).toBeInTheDocument();
+    expect(screen.getByText('לבדוק אם לקח משכנתא')).toBeInTheDocument();
+    // "1" reminder count pill.
+    expect(screen.getByLabelText('1 תזכורות')).toBeInTheDocument();
+  });
+
+  it('opens the compose form, posts a new reminder, and refreshes', async () => {
+    const user = userEvent.setup();
+    let createdBody: { title?: string; leadId?: string } = {};
+    let listCalls = 0;
+    server.use(
+      http.get('/api/reminders', () => {
+        listCalls += 1;
+        return HttpResponse.json({ items: listCalls > 1 ? BASE : [] });
+      }),
+      http.post('/api/reminders', async ({ request }) => {
+        createdBody = (await request.json()) as { title?: string; leadId?: string };
+        return HttpResponse.json({ reminder: { id: 'r2', ...createdBody, status: 'PENDING' } });
+      }),
+    );
+    render(<RemindersPanel leadId="lead-1" />);
+    await screen.findByText('אין תזכורות פתוחות');
+    await user.click(screen.getByRole('button', { name: /תזכורת חדשה/ }));
+    await user.type(screen.getByLabelText('כותרת'), 'לפגוש ביום חמישי');
+    await user.click(screen.getByRole('button', { name: /שמור/ }));
+    await waitFor(() => {
+      expect(createdBody.title).toBe('לפגוש ביום חמישי');
+      expect(createdBody.leadId).toBe('lead-1');
+    });
+  });
+
+  it('completes a reminder via the check button', async () => {
+    const user = userEvent.setup();
+    let completedId: string | null = null;
+    server.use(
+      http.get('/api/reminders', () => HttpResponse.json({ items: BASE })),
+      http.post('/api/reminders/:id/complete', ({ params }) => {
+        completedId = String(params.id);
+        return HttpResponse.json({ reminder: { id: params.id, status: 'COMPLETED' } });
+      }),
+    );
+    render(<RemindersPanel leadId="lead-1" />);
+    await screen.findByText('להתקשר ללקוח');
+    await user.click(screen.getByRole('button', { name: /סמן "להתקשר ללקוח" כהושלם/ }));
+    await waitFor(() => expect(completedId).toBe('r1'));
+  });
+
+  it('refuses to create a reminder with an empty title', async () => {
+    const user = userEvent.setup();
+    let posted = false;
+    server.use(
+      http.get('/api/reminders', () => HttpResponse.json({ items: [] })),
+      http.post('/api/reminders', () => { posted = true; return HttpResponse.json({}); }),
+    );
+    render(<RemindersPanel leadId="lead-1" />);
+    await screen.findByText('אין תזכורות פתוחות');
+    await user.click(screen.getByRole('button', { name: /תזכורת חדשה/ }));
+    await user.click(screen.getByRole('button', { name: /שמור/ }));
+    expect(posted).toBe(false);
+  });
+});

--- a/tests/frontend/components/features/TagPicker.test.tsx
+++ b/tests/frontend/components/features/TagPicker.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { render, screen, userEvent, waitFor } from '../../setup/test-utils';
+import { server } from '../../setup/msw-server';
+import TagPicker from '@estia/frontend/components/TagPicker.jsx';
+
+const TAGS = [
+  { id: 't1', name: 'תג ראשון', color: '#D4AF37', scope: 'ALL' },
+  { id: 't2', name: 'תג שני',    color: '#3B82F6', scope: 'ALL' },
+  { id: 't3', name: 'תג שלישי',  color: null,     scope: 'ALL' },
+];
+
+describe('<TagPicker>', () => {
+  it('lists assigned tags and marks the empty state when none attached', async () => {
+    server.use(
+      http.get('/api/tags',     () => HttpResponse.json({ items: TAGS })),
+      http.get('/api/tags/for', () => HttpResponse.json({ items: [] })),
+    );
+    render(<TagPicker entityType="LEAD" entityId="lead-1" />);
+    // After the initial fetch resolves, the empty chip is visible.
+    await screen.findByText('אין תגים');
+    expect(screen.getByRole('button', { name: 'הוסף תג' })).toBeInTheDocument();
+  });
+
+  it('shows assigned tags as chips and allows detaching', async () => {
+    const user = userEvent.setup();
+    let unassignedCalled = false;
+    server.use(
+      http.get('/api/tags',     () => HttpResponse.json({ items: TAGS })),
+      http.get('/api/tags/for', () => HttpResponse.json({ items: [TAGS[0]] })),
+      http.delete('/api/tags/:id/assign/:entityType/:entityId', () => {
+        unassignedCalled = true;
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+    render(<TagPicker entityType="LEAD" entityId="lead-1" />);
+    await screen.findByText('תג ראשון');
+    await user.click(screen.getByRole('button', { name: /הסר תג תג ראשון/ }));
+    await waitFor(() => expect(unassignedCalled).toBe(true));
+  });
+
+  it('opens a dropdown of available tags and attaches one on click', async () => {
+    const user = userEvent.setup();
+    let assignedBody: { entityType?: string; entityId?: string } = {};
+    server.use(
+      http.get('/api/tags',     () => HttpResponse.json({ items: TAGS })),
+      http.get('/api/tags/for', () => HttpResponse.json({ items: [] })),
+      http.post('/api/tags/:id/assign', async ({ request }) => {
+        assignedBody = (await request.json()) as { entityType?: string; entityId?: string };
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+    render(<TagPicker entityType="PROPERTY" entityId="prop-9" />);
+    await screen.findByText('אין תגים');
+    await user.click(screen.getByRole('button', { name: 'הוסף תג' }));
+    // The popover is now a listbox with all 3 catalog tags.
+    const opt = await screen.findByRole('option', { name: /תג שני/ });
+    await user.click(opt);
+    await waitFor(() => {
+      expect(assignedBody.entityType).toBe('PROPERTY');
+      expect(assignedBody.entityId).toBe('prop-9');
+    });
+  });
+
+  it('readonly mode hides add / remove controls', async () => {
+    server.use(
+      http.get('/api/tags',     () => HttpResponse.json({ items: TAGS })),
+      http.get('/api/tags/for', () => HttpResponse.json({ items: [TAGS[0]] })),
+    );
+    render(<TagPicker entityType="LEAD" entityId="lead-1" readonly />);
+    await screen.findByText('תג ראשון');
+    expect(screen.queryByRole('button', { name: 'הוסף תג' })).toBeNull();
+    expect(screen.queryByRole('button', { name: /הסר תג/ })).toBeNull();
+  });
+});

--- a/tests/frontend/components/primitives/DateRangePicker.test.tsx
+++ b/tests/frontend/components/primitives/DateRangePicker.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { axe } from 'vitest-axe';
+import { useState } from 'react';
+import { render, screen, userEvent } from '../../setup/test-utils';
+import DateRangePicker from '@estia/frontend/components/DateRangePicker.jsx';
+
+function Harness({ initialFrom = '', initialTo = '' } = {}) {
+  const [from, setFrom] = useState(initialFrom);
+  const [to, setTo] = useState(initialTo);
+  return (
+    <>
+      <DateRangePicker
+        from={from}
+        to={to}
+        onChange={({ from: f, to: t }) => { setFrom(f); setTo(t); }}
+      />
+      <output data-testid="from">{from}</output>
+      <output data-testid="to">{to}</output>
+    </>
+  );
+}
+
+describe('<DateRangePicker>', () => {
+  it('renders both date fields and the four quick-range chips', () => {
+    render(<Harness />);
+    expect(screen.getByLabelText('מתאריך')).toBeInTheDocument();
+    expect(screen.getByLabelText('עד תאריך')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '7 ימים' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'חודש' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'רבעון' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'שנה' })).toBeInTheDocument();
+  });
+
+  it('clicking a quick-range chip sets both from and to to ISO dates', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByRole('button', { name: '7 ימים' }));
+    const from = screen.getByTestId('from').textContent || '';
+    const to = screen.getByTestId('to').textContent || '';
+    expect(from).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(to).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    // 7 days apart, approximately.
+    const fromD = new Date(from + 'T00:00:00');
+    const toD = new Date(to + 'T00:00:00');
+    const days = Math.round((toD.getTime() - fromD.getTime()) / 86_400_000);
+    expect(days).toBe(7);
+  });
+
+  it('typing into the "from" field updates state via onChange', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    const fromInput = screen.getByLabelText('מתאריך') as HTMLInputElement;
+    await user.type(fromInput, '2026-01-15');
+    expect(screen.getByTestId('from').textContent).toBe('2026-01-15');
+  });
+
+  it('shows a clear button only when a value is present, and clearing resets both', async () => {
+    const user = userEvent.setup();
+    render(<Harness initialFrom="2026-01-01" initialTo="2026-01-31" />);
+    const clearBtn = screen.getByRole('button', { name: 'נקה טווח' });
+    await user.click(clearBtn);
+    expect(screen.getByTestId('from').textContent).toBe('');
+    expect(screen.getByTestId('to').textContent).toBe('');
+  });
+
+  it('does not render the clear button when both values are empty', () => {
+    render(<Harness />);
+    expect(screen.queryByRole('button', { name: 'נקה טווח' })).toBeNull();
+  });
+
+  it('no axe violations', async () => {
+    const { container } = render(<Harness />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/tests/frontend/components/primitives/DeltaBadge.test.tsx
+++ b/tests/frontend/components/primitives/DeltaBadge.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { axe } from 'vitest-axe';
+import { render, screen } from '../../setup/test-utils';
+import DeltaBadge from '@estia/frontend/components/DeltaBadge.jsx';
+
+describe('<DeltaBadge>', () => {
+  it('renders the value with a + sign for positive deltas and label', () => {
+    const { container } = render(<DeltaBadge value={3} label="השבוע" />);
+    // "+3 השבוע" — the Hebrew unit sits next to the signed number so the
+    // agent reads the pill left-to-right as a compact sentence.
+    expect(container.querySelector('.delta-num')?.textContent).toBe('+3');
+    expect(container.querySelector('.delta-label')?.textContent).toBe('השבוע');
+  });
+
+  it('renders a minus for negative deltas', () => {
+    const { container } = render(<DeltaBadge value={-2} label="החודש" />);
+    // Unicode minus (−) is the visual glyph; aria-label uses plain words.
+    expect(container.querySelector('.delta-num')?.textContent).toMatch(/[−-]2/);
+    expect(container.querySelector('.delta-label')?.textContent).toBe('החודש');
+  });
+
+  it('renders 0 without a sign when value is zero (neutral)', () => {
+    const { container } = render(<DeltaBadge value={0} label="השבוע" />);
+    expect(container.firstChild).toHaveClass('delta-badge');
+    expect(container.firstChild).toHaveClass('delta-neutral');
+  });
+
+  it('defaults direction from the sign of value (up/down/neutral)', () => {
+    const { container, rerender } = render(<DeltaBadge value={5} label="x" />);
+    expect(container.firstChild).toHaveClass('delta-up');
+    rerender(<DeltaBadge value={-1} label="x" />);
+    expect(container.firstChild).toHaveClass('delta-down');
+    rerender(<DeltaBadge value={0} label="x" />);
+    expect(container.firstChild).toHaveClass('delta-neutral');
+  });
+
+  it('direction prop overrides the sign-based default', () => {
+    const { container } = render(
+      <DeltaBadge value={3} label="x" direction="neutral" />
+    );
+    expect(container.firstChild).toHaveClass('delta-neutral');
+    expect(container.firstChild).not.toHaveClass('delta-up');
+  });
+
+  it('exposes a screen-reader friendly Hebrew sentence via sr-only', () => {
+    const { container } = render(<DeltaBadge value={3} label="השבוע" />);
+    const sr = container.querySelector('.sr-only');
+    expect(sr?.textContent || '').toMatch(/גידול של 3 לעומת/);
+    expect(sr?.textContent || '').toMatch(/השבוע/);
+  });
+
+  it('sets role="status" and an aria-label that explains the change', () => {
+    const { container } = render(<DeltaBadge value={-4} label="החודש" />);
+    const root = container.firstChild as HTMLElement;
+    expect(root.getAttribute('role')).toBe('status');
+    // A screen-reader-only description (aria-label or sr-only text) must
+    // read as a sentence, not just "-4 החודש".
+    const srText = container.querySelector('.sr-only')?.textContent || '';
+    expect(srText).toMatch(/ירידה של 4/);
+  });
+
+  it('dir="rtl" on the root so Hebrew numerals sit correctly', () => {
+    const { container } = render(<DeltaBadge value={1} label="השבוע" />);
+    expect(container.firstChild).toHaveAttribute('dir', 'rtl');
+  });
+
+  it('no axe violations', async () => {
+    const { container } = render(<DeltaBadge value={3} label="השבוע" />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('no axe violations — negative / neutral variants', async () => {
+    const { container, rerender } = render(<DeltaBadge value={-2} label="החודש" />);
+    expect(await axe(container)).toHaveNoViolations();
+    rerender(<DeltaBadge value={0} label="השבוע" />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/tests/frontend/components/primitives/FavoriteStar.test.tsx
+++ b/tests/frontend/components/primitives/FavoriteStar.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import { axe } from 'vitest-axe';
+import { render, screen, userEvent, waitFor } from '../../setup/test-utils';
+import FavoriteStar from '@estia/frontend/components/FavoriteStar.jsx';
+
+describe('<FavoriteStar>', () => {
+  it('renders an off-state button with an accessible label', () => {
+    render(<FavoriteStar active={false} onToggle={() => {}} />);
+    const btn = screen.getByRole('button', { name: /הוסף למועדפים/ });
+    expect(btn).toBeInTheDocument();
+    expect(btn).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('renders an active-state button and flips aria-pressed', () => {
+    render(<FavoriteStar active onToggle={() => {}} />);
+    const btn = screen.getByRole('button', { name: /הסר ממועדפים/ });
+    expect(btn).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('invokes onToggle(nextActive) when clicked', async () => {
+    const user = userEvent.setup();
+    const onToggle = vi.fn();
+    render(<FavoriteStar active={false} onToggle={onToggle} />);
+    await user.click(screen.getByRole('button'));
+    expect(onToggle).toHaveBeenCalledWith(true);
+  });
+
+  it('passes the opposite state when toggling an already-active star', async () => {
+    const user = userEvent.setup();
+    const onToggle = vi.fn();
+    render(<FavoriteStar active onToggle={onToggle} />);
+    await user.click(screen.getByRole('button'));
+    expect(onToggle).toHaveBeenCalledWith(false);
+  });
+
+  it('does NOT bubble click events to ancestors (stopPropagation)', async () => {
+    const user = userEvent.setup();
+    const ancestorClick = vi.fn();
+    render(
+      <div onClick={ancestorClick}>
+        <FavoriteStar active={false} onToggle={() => {}} />
+      </div>
+    );
+    await user.click(screen.getByRole('button'));
+    expect(ancestorClick).not.toHaveBeenCalled();
+  });
+
+  it('awaits an async onToggle and surfaces errors without flipping state', async () => {
+    const user = userEvent.setup();
+    const onToggle = vi.fn().mockRejectedValue(new Error('boom'));
+    render(<FavoriteStar active={false} onToggle={onToggle} />);
+    await user.click(screen.getByRole('button'));
+    // The component must not throw — caller surfaces the error.
+    await waitFor(() => expect(onToggle).toHaveBeenCalled());
+  });
+
+  it('passes axe', async () => {
+    const { baseElement } = render(<FavoriteStar active={false} onToggle={() => {}} />);
+    expect(await axe(baseElement)).toHaveNoViolations();
+  });
+});

--- a/tests/frontend/hooks/useDashboardDeltas.test.tsx
+++ b/tests/frontend/hooks/useDashboardDeltas.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { renderHook, waitFor } from '@testing-library/react';
+// eslint-disable-next-line import/no-relative-packages
+import useDashboardDeltas from '@estia/frontend/hooks/useDashboardDeltas.js';
+import { server } from '../setup/msw-server';
+
+describe('useDashboardDeltas', () => {
+  it('starts in a loading state before any fetch resolves', () => {
+    const { result } = renderHook(() => useDashboardDeltas('week'));
+    expect(result.current.loading).toBe(true);
+    expect(result.current.week).toBeDefined();
+    expect(result.current.week.properties).toBe(0);
+  });
+
+  it('resolves week/month/quarter buckets from the three report endpoints', async () => {
+    server.use(
+      http.get('/api/reports/new-properties', ({ request }) => {
+        // Each window gets a different count so we can verify the fan-out
+        // actually maps to distinct buckets.
+        const url = new URL(request.url);
+        const from = url.searchParams.get('from') || '';
+        const days = daysAgo(from);
+        const count = days <= 8 ? 3 : days <= 31 ? 12 : 40;
+        return HttpResponse.json({ items: [], count });
+      }),
+      http.get('/api/reports/new-customers', ({ request }) => {
+        const url = new URL(request.url);
+        const days = daysAgo(url.searchParams.get('from') || '');
+        const count = days <= 8 ? 2 : days <= 31 ? 7 : 20;
+        return HttpResponse.json({ items: [], count });
+      }),
+      http.get('/api/reports/deals', ({ request }) => {
+        const url = new URL(request.url);
+        const days = daysAgo(url.searchParams.get('from') || '');
+        const count = days <= 8 ? 1 : days <= 31 ? 4 : 9;
+        return HttpResponse.json({ items: [], count, totalCommission: 0, byStatus: {} });
+      })
+    );
+
+    const { result } = renderHook(() => useDashboardDeltas('week'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.week).toEqual({ properties: 3, customers: 2, deals: 1 });
+    expect(result.current.month).toEqual({ properties: 12, customers: 7, deals: 4 });
+    expect(result.current.quarter).toEqual({ properties: 40, customers: 20, deals: 9 });
+    expect(result.current.error).toBeFalsy();
+  });
+
+  it('degrades gracefully when one sub-call fails — other buckets still resolve', async () => {
+    server.use(
+      http.get('/api/reports/new-properties', () =>
+        HttpResponse.json({ error: { message: 'boom' } }, { status: 500 })
+      ),
+      http.get('/api/reports/new-customers', () =>
+        HttpResponse.json({ items: [], count: 5 })
+      ),
+      http.get('/api/reports/deals', () =>
+        HttpResponse.json({ items: [], count: 2, totalCommission: 0, byStatus: {} })
+      )
+    );
+
+    const { result } = renderHook(() => useDashboardDeltas('week'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    // Properties failed — it should surface as `null` (unknown) rather
+    // than poisoning the other numbers.
+    expect(result.current.week.properties).toBeNull();
+    expect(result.current.week.customers).toBe(5);
+    expect(result.current.week.deals).toBe(2);
+  });
+
+  it('fires nine requests in parallel (3 windows × 3 endpoints) on mount', async () => {
+    const seen: string[] = [];
+    server.use(
+      http.get('/api/reports/new-properties', ({ request }) => {
+        seen.push(`properties:${daysAgo(new URL(request.url).searchParams.get('from') || '')}`);
+        return HttpResponse.json({ items: [], count: 0 });
+      }),
+      http.get('/api/reports/new-customers', ({ request }) => {
+        seen.push(`customers:${daysAgo(new URL(request.url).searchParams.get('from') || '')}`);
+        return HttpResponse.json({ items: [], count: 0 });
+      }),
+      http.get('/api/reports/deals', ({ request }) => {
+        seen.push(`deals:${daysAgo(new URL(request.url).searchParams.get('from') || '')}`);
+        return HttpResponse.json({ items: [], count: 0, totalCommission: 0, byStatus: {} });
+      })
+    );
+    const { result } = renderHook(() => useDashboardDeltas('week'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    // Nine total calls (three endpoints × three windows).
+    expect(seen.length).toBe(9);
+    // Each window should appear for each of the three endpoints.
+    const properties = seen.filter((s) => s.startsWith('properties:')).sort();
+    expect(properties.length).toBe(3);
+  });
+
+  it('does not setState after unmount (no late-resolve leaks)', async () => {
+    let resolve: (v: Response) => void = () => {};
+    server.use(
+      http.get('/api/reports/new-properties', () =>
+        new Promise<Response>((r) => { resolve = r; })
+      )
+    );
+    const { unmount } = renderHook(() => useDashboardDeltas('week'));
+    unmount();
+    // Fulfil the pending promise AFTER unmount — if the hook wrote to
+    // state it would throw the "can't setState on unmounted" warning.
+    resolve(HttpResponse.json({ items: [], count: 1 }));
+    // A brief tick is enough to flush any pending microtask.
+    await new Promise((r) => setTimeout(r, 10));
+    // No assertion beyond "didn't throw" is needed; React will log a
+    // warning that would fail the test if state was updated.
+    expect(true).toBe(true);
+  });
+});
+
+// Helper — given an ISO date string `from`, returns days between
+// `from` and "now" (rounded up). The hook passes 7 / 30 / 90 day
+// windows, so this lets MSW handlers pick a bucket deterministically.
+function daysAgo(iso: string): number {
+  if (!iso) return 0;
+  const t = new Date(iso).getTime();
+  if (!Number.isFinite(t)) return 0;
+  return Math.ceil((Date.now() - t) / 86400000);
+}

--- a/tests/frontend/hooks/useNeighborhoodSuggestions.test.tsx
+++ b/tests/frontend/hooks/useNeighborhoodSuggestions.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { http, HttpResponse, delay as mswDelay } from 'msw';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { server } from '../setup/msw-server';
+// eslint-disable-next-line import/no-relative-packages
+import { useNeighborhoodSuggestions } from '@estia/frontend/hooks/useNeighborhoodSuggestions.js';
+
+// The hook takes (city, query) and returns {items, loading, error}. It
+// debounces the query by 200ms, cancels stale requests when city/query
+// changes, and skips the fetch entirely when either side is empty.
+
+afterEach(() => { vi.useRealTimers(); });
+
+describe('useNeighborhoodSuggestions', () => {
+  beforeEach(() => {
+    // Default handler returning a tiny fixture the individual tests can
+    // override via server.use().
+    server.use(
+      http.get('/api/neighborhoods', ({ request }) => {
+        const url = new URL(request.url);
+        const city = url.searchParams.get('city') || '';
+        const search = url.searchParams.get('search') || '';
+        return HttpResponse.json({
+          items: [
+            { id: 'n1', city, name: `${search}-שכונה-א`, aliases: [] },
+            { id: 'n2', city, name: `${search}-שכונה-ב`, aliases: [] },
+          ],
+        });
+      }),
+    );
+  });
+
+  it('returns empty items when no city is set, regardless of query', async () => {
+    const { result } = renderHook(() => useNeighborhoodSuggestions('', 'פלו'));
+    // Never fetches — so loading stays false and items stay empty.
+    expect(result.current.items).toEqual([]);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('returns empty items when the query is shorter than the minimum', async () => {
+    const { result } = renderHook(() => useNeighborhoodSuggestions('תל אביב', ''));
+    expect(result.current.items).toEqual([]);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('fetches neighborhoods after the 200ms debounce window', async () => {
+    vi.useFakeTimers();
+    const { result, rerender } = renderHook(
+      ({ q }: { q: string }) => useNeighborhoodSuggestions('תל אביב', q),
+      { initialProps: { q: '' } },
+    );
+    rerender({ q: 'פלו' });
+    // Nothing has fired yet — debounce timer hasn't expired.
+    expect(result.current.items).toEqual([]);
+    await act(async () => { await vi.advanceTimersByTimeAsync(199); });
+    expect(result.current.items).toEqual([]);
+    // After 200ms the fetch kicks off; flush microtasks so MSW resolves.
+    await act(async () => { await vi.advanceTimersByTimeAsync(1); });
+    vi.useRealTimers();
+    await waitFor(() => {
+      expect(result.current.items.length).toBeGreaterThan(0);
+    });
+    expect(result.current.items[0]).toMatchObject({ city: 'תל אביב' });
+  });
+
+  it('cancels stale in-flight requests when the query changes quickly', async () => {
+    // First request is slow; second is fast. The hook should discard the
+    // first response when the second returns.
+    let callCount = 0;
+    server.use(
+      http.get('/api/neighborhoods', async ({ request }) => {
+        callCount += 1;
+        const url = new URL(request.url);
+        const search = url.searchParams.get('search') || '';
+        if (search === 'פלו') {
+          await mswDelay(300);
+          return HttpResponse.json({
+            items: [{ id: 'stale', city: 'תל אביב', name: 'סטייל', aliases: [] }],
+          });
+        }
+        return HttpResponse.json({
+          items: [{ id: 'fresh', city: 'תל אביב', name: 'פרש', aliases: [] }],
+        });
+      }),
+    );
+
+    const { result, rerender } = renderHook(
+      ({ q }: { q: string }) => useNeighborhoodSuggestions('תל אביב', q),
+      { initialProps: { q: 'פלו' } },
+    );
+
+    // Let the first debounce expire + the slow request begin.
+    await new Promise((r) => setTimeout(r, 220));
+    rerender({ q: 'פלור' });
+    // Wait for the fresh one to resolve.
+    await waitFor(() => {
+      expect(result.current.items.some((x) => x.id === 'fresh')).toBe(true);
+    }, { timeout: 2000 });
+    // The stale response, if it arrives, must not overwrite items.
+    await new Promise((r) => setTimeout(r, 400));
+    expect(result.current.items.some((x) => x.id === 'stale')).toBe(false);
+    expect(callCount).toBeGreaterThanOrEqual(2);
+  });
+
+  it('does not leak state when unmounted mid-flight', async () => {
+    server.use(
+      http.get('/api/neighborhoods', async () => {
+        await mswDelay(200);
+        return HttpResponse.json({ items: [] });
+      }),
+    );
+    const { unmount } = renderHook(() =>
+      useNeighborhoodSuggestions('תל אביב', 'פלו'),
+    );
+    await new Promise((r) => setTimeout(r, 210));
+    unmount();
+    // Nothing crashes (no "setState on unmounted" warnings). The test
+    // just asserting no throw is enough; happy-dom surfaces warnings as
+    // unhandled rejections when they matter.
+    await new Promise((r) => setTimeout(r, 100));
+  });
+});

--- a/tests/frontend/pages/ActivityLog.test.tsx
+++ b/tests/frontend/pages/ActivityLog.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { render, screen, userEvent, waitFor } from '../setup/test-utils';
+import { server } from '../setup/msw-server';
+import ActivityLog from '@estia/frontend/pages/ActivityLog.jsx';
+
+describe('<ActivityLog>', () => {
+  it('renders the empty state when the feed has no entries', async () => {
+    render(<ActivityLog />);
+    expect(await screen.findByRole('heading', { name: 'יומן פעילות' })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('אין פעילות להצגה')).toBeInTheDocument();
+    });
+  });
+
+  it('renders activity items with action + summary + formatted timestamp', async () => {
+    server.use(
+      http.get('/api/activity', () =>
+        HttpResponse.json({
+          items: [
+            {
+              id: 'a1',
+              entityType: 'PROPERTY',
+              entityId: 'p1',
+              action: 'יצירה',
+              summary: 'נוסף נכס חדש',
+              actorName: 'יוסי',
+              createdAt: '2026-04-20T10:00:00Z',
+            },
+          ],
+        })
+      )
+    );
+    render(<ActivityLog />);
+    expect(await screen.findByText('יצירה')).toBeInTheDocument();
+    expect(screen.getByText('נוסף נכס חדש')).toBeInTheDocument();
+    expect(screen.getByText(/על ידי/)).toBeInTheDocument();
+  });
+
+  it('filtering by entityType forwards the chosen type as a query param', async () => {
+    const user = userEvent.setup();
+    const seen: string[] = [];
+    server.use(
+      http.get('/api/activity', ({ request }) => {
+        const url = new URL(request.url);
+        seen.push(url.searchParams.get('entityType') ?? '');
+        return HttpResponse.json({ items: [] });
+      })
+    );
+    render(<ActivityLog />);
+    await waitFor(() => expect(seen.length).toBeGreaterThan(0));
+    await user.click(screen.getByRole('button', { name: 'נכסים' }));
+    await waitFor(() => expect(seen).toContain('PROPERTY'));
+  });
+
+  it('changing the limit dropdown refetches with the new value', async () => {
+    const user = userEvent.setup();
+    const seenLimits: string[] = [];
+    server.use(
+      http.get('/api/activity', ({ request }) => {
+        const url = new URL(request.url);
+        seenLimits.push(url.searchParams.get('limit') ?? '');
+        return HttpResponse.json({ items: [] });
+      })
+    );
+    render(<ActivityLog />);
+    await waitFor(() => expect(seenLimits).toContain('50'));
+    const select = screen.getByLabelText('מספר שורות');
+    await user.selectOptions(select, '100');
+    await waitFor(() => expect(seenLimits).toContain('100'));
+  });
+});

--- a/tests/frontend/pages/CustomerDetail.test.jsx
+++ b/tests/frontend/pages/CustomerDetail.test.jsx
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { render, screen, userEvent, waitFor } from '../setup/test-utils';
+import { server } from '../setup/msw-server';
+import CustomerDetail from '@estia/frontend/pages/CustomerDetail.jsx';
+
+function seedLead(overrides = {}) {
+  return {
+    id: 'lead-1',
+    name: 'דני לוי',
+    phone: '050-1111111',
+    email: null,
+    status: 'WARM',
+    interestType: 'PRIVATE',
+    lookingFor: 'BUY',
+    city: 'תל אביב',
+    street: '',
+    rooms: '4',
+    budget: 2_800_000,
+    sector: 'כללי',
+    createdAt: '2026-04-01T00:00:00.000Z',
+    customerStatus: 'ACTIVE',
+    leadStatus: 'NEW',
+    purposes: [],
+    isPrivate: false,
+    seriousnessOverride: 'NONE',
+    firstName: '',
+    lastName:  '',
+    ...overrides,
+  };
+}
+
+function mountLead(lead) {
+  // The real backend returns the lead object directly (no envelope),
+  // so mirror that here — a {lead: ...} wrap breaks CustomerDetail's
+  // `fetched.name` path.
+  server.use(
+    http.get('/api/leads/:id', () => HttpResponse.json(lead)),
+    http.get('/api/leads', () => HttpResponse.json({ items: [lead] })),
+  );
+}
+
+describe('<CustomerDetail>', () => {
+  it('renders the lead header and the MLS-parity side panels', async () => {
+    mountLead(seedLead());
+    render(<CustomerDetail />, { route: '/customers/lead-1', path: '/customers/:id' });
+
+    // The crumb + name appear once the lead resolves.
+    await screen.findByText('דני לוי');
+    // Shared panels mount with their own section headings. Some may
+    // appear more than once because the parent page re-fetches after a
+    // save; we only care that each panel appears at least once.
+    expect((await screen.findAllByRole('heading', { name: /תזכורות/ })).length).toBeGreaterThan(0);
+    expect((await screen.findAllByRole('heading', { name: /נכסים תואמים/ })).length).toBeGreaterThan(0);
+    expect((await screen.findAllByRole('heading', { name: /יומן פעילות/ })).length).toBeGreaterThan(0);
+    expect((await screen.findAllByRole('heading', { name: /פרופילי חיפוש/ })).length).toBeGreaterThan(0);
+    // Tags region and "הוסף" attach button.
+    expect((await screen.findAllByRole('button', { name: 'הוסף תג' }))[0]).toBeInTheDocument();
+  });
+
+  it('attaches a tag via TagPicker', async () => {
+    mountLead(seedLead());
+    let assignedForId = null;
+    server.use(
+      http.get('/api/tags', () =>
+        HttpResponse.json({ items: [{ id: 't1', name: 'חם ביותר', color: '#D4AF37' }] })
+      ),
+      http.get('/api/tags/for', () => HttpResponse.json({ items: [] })),
+      http.post('/api/tags/:id/assign', async ({ params, request }) => {
+        assignedForId = String(params.id);
+        await request.json(); // drain
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+    const user = userEvent.setup();
+    render(<CustomerDetail />, { route: '/customers/lead-1', path: '/customers/:id' });
+    await screen.findByText('דני לוי');
+    await user.click(await screen.findByRole('button', { name: 'הוסף תג' }));
+    const opt = await screen.findByRole('option', { name: /חם ביותר/ });
+    await user.click(opt);
+    await waitFor(() => expect(assignedForId).toBe('t1'));
+  });
+
+  it('creates a reminder through the embedded RemindersPanel', async () => {
+    mountLead(seedLead());
+    let body = {};
+    server.use(
+      http.get('/api/reminders', () => HttpResponse.json({ items: [] })),
+      http.post('/api/reminders', async ({ request }) => {
+        body = await request.json();
+        return HttpResponse.json({ reminder: { id: 'r-new', ...body, status: 'PENDING' } });
+      }),
+    );
+    const user = userEvent.setup();
+    render(<CustomerDetail />, { route: '/customers/lead-1', path: '/customers/:id' });
+    await screen.findByText('דני לוי');
+    await user.click(await screen.findByRole('button', { name: /תזכורת חדשה/ }));
+    await user.type(screen.getByLabelText('כותרת'), 'לחזור בחמישי');
+    // Exact match "שמור" — the "שמור שינויים" button on the edit form
+    // must not match.
+    await user.click(screen.getByRole('button', { name: 'שמור' }));
+    await waitFor(() => {
+      expect(body.title).toBe('לחזור בחמישי');
+      expect(body.leadId).toBe('lead-1');
+    });
+  });
+
+  it('renders property matches in the MatchingList panel', async () => {
+    mountLead(seedLead());
+    server.use(
+      http.get('/api/leads/:id/matches', () =>
+        HttpResponse.json({
+          items: [{
+            id: 'm1',
+            score: 77,
+            reasons: ['עיר תואמת'],
+            property: { id: 'p1', title: '4ח׳ בגבעתיים', price: 2_900_000 },
+          }],
+        })
+      ),
+    );
+    render(<CustomerDetail />, { route: '/customers/lead-1', path: '/customers/:id' });
+    expect(await screen.findByText('4ח׳ בגבעתיים')).toBeInTheDocument();
+    expect(screen.getByText('77')).toBeInTheDocument();
+  });
+
+  it('updates K1/K2/L1 fields via PATCH /api/leads/:id', async () => {
+    mountLead(seedLead());
+    let patchBody = {};
+    server.use(
+      http.patch('/api/leads/:id', async ({ request }) => {
+        patchBody = await request.json();
+        return HttpResponse.json({ lead: { id: 'lead-1', ...patchBody } });
+      }),
+    );
+    const user = userEvent.setup();
+    render(<CustomerDetail />, { route: '/customers/lead-1', path: '/customers/:id' });
+    await screen.findByText('דני לוי');
+    // Toggle isPrivate (exists in the K2 block).
+    await user.click(screen.getByRole('checkbox', { name: /לקוח פרטי/ }));
+    // Set a lead-status.
+    await user.selectOptions(screen.getByLabelText('סטטוס ליד'), 'IN_PROGRESS');
+    await user.click(screen.getAllByRole('button', { name: /שמור שינויים/ })[0]);
+    await waitFor(() => {
+      expect(patchBody.isPrivate).toBe(true);
+      expect(patchBody.leadStatus).toBe('IN_PROGRESS');
+    });
+  });
+
+  it('lists search profiles and lets the agent add one', async () => {
+    mountLead(seedLead());
+    let created = false;
+    let listCalls = 0;
+    server.use(
+      http.get('/api/leads/:leadId/search-profiles', () => {
+        listCalls += 1;
+        return HttpResponse.json({ items: [] });
+      }),
+      http.post('/api/leads/:leadId/search-profiles', () => {
+        created = true;
+        return HttpResponse.json({ profile: { id: 'sp-new', label: 'חיפוש חדש', cities: [] } });
+      }),
+    );
+    const user = userEvent.setup();
+    render(<CustomerDetail />, { route: '/customers/lead-1', path: '/customers/:id' });
+    await screen.findByText('דני לוי');
+    await user.click(await screen.findByRole('button', { name: /פרופיל חדש/ }));
+    await waitFor(() => expect(created).toBe(true));
+    expect(listCalls).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/tests/frontend/pages/Customers.test.jsx
+++ b/tests/frontend/pages/Customers.test.jsx
@@ -1,0 +1,179 @@
+// Sprint 2 C2 + Sprint 7 B3/B4 — Customers page integration test.
+// Covers the new Nadlan-parity filter drawer, saved-search menu, and
+// favorite-star toggle on each lead row. Existing behavior (search,
+// tabs, sort, delete) is covered elsewhere via unit tests of the page's
+// helpers + by the mobile-specific composite tests; this file focuses
+// on the new feature surface.
+
+import { describe, it, expect, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { render, screen, userEvent, waitFor, within } from '../setup/test-utils';
+import { server } from '../setup/msw-server';
+import Customers from '@estia/frontend/pages/Customers.jsx';
+
+const sampleLeads = [
+  {
+    id: 'l1', name: 'דנה אבני', phone: '050-1111111', city: 'תל אביב',
+    lookingFor: 'BUY', interestType: 'PRIVATE', status: 'HOT', rooms: 4,
+  },
+  {
+    id: 'l2', name: 'רון כהן', phone: '050-2222222', city: 'חיפה',
+    lookingFor: 'RENT', interestType: 'COMMERCIAL', status: 'WARM', rooms: 3,
+  },
+];
+
+function mountLeads(items = sampleLeads) {
+  server.use(
+    http.get('/api/leads', () => HttpResponse.json({ items }))
+  );
+}
+
+describe('<Customers> filter + saved-search + favorite', () => {
+  it('renders the lead rows once /api/leads resolves', async () => {
+    mountLeads();
+    render(<Customers />, { route: '/customers' });
+    await screen.findByText('דנה אבני');
+    expect(screen.getByText('רון כהן')).toBeInTheDocument();
+  });
+
+  it('opens the advanced filter panel when "סינון מתקדם" is clicked', async () => {
+    const user = userEvent.setup({ delay: null });
+    mountLeads();
+    render(<Customers />, { route: '/customers' });
+    await screen.findByText('דנה אבני');
+    // The filter trigger is visible on desktop; aria-label is the
+    // stable anchor across layouts.
+    await user.click(screen.getByRole('button', { name: /סינון מתקדם/ }));
+    expect(await screen.findByRole('dialog', { name: 'סינון מתקדם' })).toBeInTheDocument();
+  });
+
+  it('applying a filter re-fetches /api/leads with the new query', async () => {
+    const user = userEvent.setup({ delay: null });
+    const requests = [];
+    server.use(
+      http.get('/api/leads', ({ request }) => {
+        const url = new URL(request.url);
+        requests.push(url.searchParams.toString());
+        return HttpResponse.json({ items: sampleLeads });
+      })
+    );
+    render(<Customers />, { route: '/customers' });
+    await screen.findByText('דנה אבני');
+    // Initial fetch has no filters.
+    expect(requests[0]).toBe('');
+    await user.click(screen.getByRole('button', { name: /סינון מתקדם/ }));
+    // Pick HOT in lead heat. Scope to the drawer because the page
+    // header has its own "חם" quick-filter tab.
+    const dialog = await screen.findByRole('dialog', { name: 'סינון מתקדם' });
+    const dialogScope = within(dialog);
+    await user.click(dialogScope.getByRole('button', { name: /^חם$/ }));
+    await user.click(dialogScope.getByRole('button', { name: /החל סינון/ }));
+    // Wait for the re-fetch that carries the `heat=HOT` parameter.
+    await waitFor(() => {
+      expect(requests.some((q) => q.includes('heat=HOT'))).toBe(true);
+    });
+  });
+
+  it('shows an active-filter count pill on the filter trigger after applying', async () => {
+    const user = userEvent.setup({ delay: null });
+    mountLeads();
+    render(<Customers />, { route: '/customers' });
+    await screen.findByText('דנה אבני');
+    await user.click(screen.getByRole('button', { name: /סינון מתקדם/ }));
+    const dialog = await screen.findByRole('dialog', { name: 'סינון מתקדם' });
+    const d = within(dialog);
+    await user.click(d.getByRole('button', { name: /^חם$/ }));
+    await user.click(d.getByRole('button', { name: /מעלית/ }));
+    await user.click(d.getByRole('button', { name: /החל סינון/ }));
+    // After apply, the trigger button's accessible name includes the count.
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /סינון מתקדם.*2/ })).toBeInTheDocument();
+    });
+  });
+
+  it('saved-search menu trigger is present in the toolbar', async () => {
+    mountLeads();
+    render(<Customers />, { route: '/customers' });
+    await screen.findByText('דנה אבני');
+    expect(screen.getByRole('button', { name: /חיפושים שמורים/ })).toBeInTheDocument();
+  });
+
+  it('toggling the star on a row POSTs to /api/favorites', async () => {
+    const user = userEvent.setup({ delay: null });
+    mountLeads();
+    let postedBody = null;
+    server.use(
+      http.post('/api/favorites', async ({ request }) => {
+        postedBody = await request.json();
+        return HttpResponse.json({
+          favorite: {
+            id: 'fav-1', agentId: 'a1', entityType: 'LEAD',
+            entityId: postedBody.entityId, createdAt: new Date().toISOString(),
+          },
+        });
+      })
+    );
+    render(<Customers />, { route: '/customers' });
+    await screen.findByText('דנה אבני');
+    // Each row renders a FavoriteStar labelled "הוסף למועדפים". Multiple
+    // rows → multiple buttons; pick the first one (associated with l1).
+    const stars = await screen.findAllByRole('button', { name: /הוסף למועדפים/ });
+    expect(stars.length).toBeGreaterThan(0);
+    await user.click(stars[0]);
+    await waitFor(() => expect(postedBody).not.toBeNull());
+    expect(postedBody).toMatchObject({ entityType: 'LEAD', entityId: 'l1' });
+  });
+
+  it('"only favorites" toggle filters the list to favorited leads', async () => {
+    const user = userEvent.setup({ delay: null });
+    server.use(
+      http.get('/api/leads', () => HttpResponse.json({ items: sampleLeads })),
+      http.get('/api/favorites', () =>
+        HttpResponse.json({
+          items: [{
+            id: 'fv', agentId: 'a1', entityType: 'LEAD', entityId: 'l2',
+            createdAt: '2026-04-10T00:00:00.000Z',
+          }],
+        })
+      )
+    );
+    render(<Customers />, { route: '/customers' });
+    await screen.findByText('דנה אבני');
+    // Both visible initially.
+    expect(screen.getByText('רון כהן')).toBeInTheDocument();
+    // Toggle "רק מועדפים"
+    await user.click(screen.getByRole('button', { name: /רק מועדפים/ }));
+    // l2 (רון כהן) is favorited, l1 should disappear.
+    await waitFor(() => {
+      expect(screen.queryByText('דנה אבני')).toBeNull();
+    });
+    expect(screen.getByText('רון כהן')).toBeInTheDocument();
+  });
+
+  it('loading a saved search applies its filters and re-fetches', async () => {
+    const user = userEvent.setup({ delay: null });
+    const requests = [];
+    server.use(
+      http.get('/api/leads', ({ request }) => {
+        const url = new URL(request.url);
+        requests.push(url.searchParams.toString());
+        return HttpResponse.json({ items: sampleLeads });
+      }),
+      http.get('/api/saved-searches', () =>
+        HttpResponse.json({
+          items: [{
+            id: 'ss-1', entityType: 'LEAD', name: 'חמים בלבד',
+            filters: { heat: ['WARM'] }, createdAt: '2026-04-10T00:00:00.000Z',
+          }],
+        })
+      )
+    );
+    render(<Customers />, { route: '/customers' });
+    await screen.findByText('דנה אבני');
+    await user.click(screen.getByRole('button', { name: /חיפושים שמורים/ }));
+    await user.click(await screen.findByText('חמים בלבד'));
+    await waitFor(() => {
+      expect(requests.some((q) => q.includes('heat=WARM'))).toBe(true);
+    });
+  });
+});

--- a/tests/frontend/pages/Dashboard.test.tsx
+++ b/tests/frontend/pages/Dashboard.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { http, HttpResponse } from 'msw';
-import { render, screen, waitFor } from '../setup/test-utils';
+import { render, screen, userEvent, waitFor } from '../setup/test-utils';
 import { server } from '../setup/msw-server';
 import Dashboard from '@estia/frontend/pages/Dashboard.jsx';
 
@@ -30,5 +30,95 @@ describe('<Dashboard>', () => {
     // The page should still render its header/greeting even if the
     // numbers API fails.
     await waitFor(() => expect(screen.getByRole('heading', { name: /שלום/ })).toBeInTheDocument());
+  });
+
+  it('B2 — renders DeltaBadge counters next to KPI tiles on mount', async () => {
+    server.use(
+      http.get('/api/reports/new-properties', () =>
+        HttpResponse.json({ items: [], count: 5 })
+      ),
+      http.get('/api/reports/new-customers', () =>
+        HttpResponse.json({ items: [], count: 4 })
+      ),
+      http.get('/api/reports/deals', () =>
+        HttpResponse.json({ items: [], count: 2, totalCommission: 0, byStatus: {} })
+      )
+    );
+    render(<Dashboard />);
+    // Wait for the KPI grid to render, then the pills arrive after
+    // the delta fan-out settles.
+    await waitFor(() =>
+      expect(
+        screen.getByRole('heading', { name: /שלום/ })
+      ).toBeInTheDocument()
+    );
+    await waitFor(() => {
+      // At least one of the delta pills should be visible; the pill
+      // announces a full Hebrew sentence via its sr-only span, so we
+      // can match on that deterministically.
+      const matches = screen.getAllByText(/גידול של \d+ לעומת השבוע הקודם/);
+      expect(matches.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('B2 — switching the period re-labels the delta pills', async () => {
+    server.use(
+      http.get('/api/reports/new-properties', () =>
+        HttpResponse.json({ items: [], count: 1 })
+      ),
+      http.get('/api/reports/new-customers', () =>
+        HttpResponse.json({ items: [], count: 1 })
+      ),
+      http.get('/api/reports/deals', () =>
+        HttpResponse.json({ items: [], count: 1, totalCommission: 0, byStatus: {} })
+      )
+    );
+    const user = userEvent.setup();
+    render(<Dashboard />);
+    await waitFor(() =>
+      expect(
+        screen.getByRole('heading', { name: /שלום/ })
+      ).toBeInTheDocument()
+    );
+    // Pills start in "week" mode.
+    await waitFor(() => {
+      expect(screen.getAllByText(/לעומת השבוע הקודם/).length).toBeGreaterThan(0);
+    });
+    // Click the "חודש" segment in the period switcher.
+    const monthBtn = screen.getByRole('radio', { name: 'חודש' });
+    await user.click(monthBtn);
+    await waitFor(() => {
+      expect(screen.getAllByText(/לעומת החודש הקודם/).length).toBeGreaterThan(0);
+    });
+  });
+
+  it('B2 — a failing sub-call degrades gracefully (KPI total still renders)', async () => {
+    server.use(
+      http.get('/api/reports/new-properties', () =>
+        HttpResponse.json({ error: { message: 'boom' } }, { status: 500 })
+      ),
+      http.get('/api/reports/new-customers', () =>
+        HttpResponse.json({ items: [], count: 3 })
+      ),
+      http.get('/api/reports/deals', () =>
+        HttpResponse.json({ items: [], count: 1, totalCommission: 0, byStatus: {} })
+      )
+    );
+    render(<Dashboard />);
+    // KPI labels themselves are driven by /api/reports/dashboard and
+    // should still render regardless of which delta endpoint is down.
+    await waitFor(() =>
+      expect(
+        screen.getByRole('heading', { name: /שלום/ })
+      ).toBeInTheDocument()
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/נכסי מגורים פעילים/)).toBeInTheDocument();
+    });
+    // And at least the customers delta should still announce itself —
+    // one broken endpoint must not blank the whole counters row.
+    await waitFor(() => {
+      expect(screen.getAllByText(/גידול של 3 לעומת השבוע הקודם/).length).toBeGreaterThan(0);
+    });
   });
 });

--- a/tests/frontend/pages/NewLead.test.jsx
+++ b/tests/frontend/pages/NewLead.test.jsx
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { render, screen, userEvent, waitFor } from '../setup/test-utils';
+import { server } from '../setup/msw-server';
+import NewLead from '@estia/frontend/pages/NewLead.jsx';
+
+describe('<NewLead>', () => {
+  it('renders the four sections including the K1/K2/L1 additions', () => {
+    render(<NewLead />);
+    expect(screen.getByRole('heading', { name: 'ליד חדש' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'פרטים אישיים' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'פרטים מורחבים' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'ניהול ולקוח' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'הערות' })).toBeInTheDocument();
+  });
+
+  it('blocks save and shows an error when name is empty', async () => {
+    const user = userEvent.setup();
+    let created = false;
+    server.use(
+      http.post('/api/leads', () => { created = true; return HttpResponse.json({ id: 'x' }); })
+    );
+    render(<NewLead />);
+    await user.click(screen.getAllByRole('button', { name: /שמור ליד/ })[0]);
+    expect(created).toBe(false);
+  });
+
+  it('POSTs the new K1/K2/L1 fields when the form is saved', async () => {
+    const user = userEvent.setup();
+    let body = {};
+    server.use(
+      http.post('/api/leads', async ({ request }) => {
+        body = await request.json();
+        return HttpResponse.json({ id: 'lead-new' });
+      })
+    );
+    render(<NewLead />);
+
+    // Required — the name input has the placeholder "שם מלא".
+    await user.type(screen.getByPlaceholderText('שם מלא'), 'דני לוי');
+
+    // K1 — fill a subset that proves the fields are wired up.
+    await user.type(screen.getByLabelText('שם פרטי'), 'דני');
+    await user.type(screen.getByLabelText('שם משפחה'), 'לוי');
+    await user.type(screen.getByLabelText('ת.ז / ח.פ'), '123456789');
+    await user.type(screen.getByLabelText('מיקוד'), '5252525');
+
+    // K2 — pick a customerStatus other than ACTIVE.
+    await user.selectOptions(screen.getByLabelText('סטטוס לקוח'), 'PAUSED');
+    // K2 — purpose multi-select: pick השקעה (INVESTMENT).
+    await user.click(screen.getByRole('checkbox', { name: 'השקעה' }));
+    // L1 — leadStatus NOT_INTERESTED.
+    await user.selectOptions(screen.getByLabelText('סטטוס ליד'), 'NOT_INTERESTED');
+
+    await user.click(screen.getAllByRole('button', { name: /שמור ליד/ })[0]);
+
+    await waitFor(() => {
+      expect(body.name).toBe('דני לוי');
+      expect(body.firstName).toBe('דני');
+      expect(body.lastName).toBe('לוי');
+      expect(body.personalId).toBe('123456789');
+      expect(body.zip).toBe('5252525');
+      expect(body.customerStatus).toBe('PAUSED');
+      expect(body.purposes).toEqual(['INVESTMENT']);
+      expect(body.leadStatus).toBe('NOT_INTERESTED');
+      // Defaults flow through even when the agent didn't touch them.
+      expect(body.seriousnessOverride).toBe('NONE');
+      expect(body.isPrivate).toBe(false);
+    });
+  });
+
+  it('toggles the isPrivate admin flag', async () => {
+    const user = userEvent.setup();
+    let body = {};
+    server.use(
+      http.post('/api/leads', async ({ request }) => {
+        body = await request.json();
+        return HttpResponse.json({ id: 'lead-new' });
+      })
+    );
+    render(<NewLead />);
+    await user.type(screen.getByPlaceholderText('שם מלא'), 'שרה');
+    await user.click(screen.getByRole('checkbox', { name: /לקוח פרטי/ }));
+    await user.click(screen.getAllByRole('button', { name: /שמור ליד/ })[0]);
+    await waitFor(() => expect(body.isPrivate).toBe(true));
+  });
+
+  it('adds and removes multiple purposes on repeated click', async () => {
+    const user = userEvent.setup();
+    let body = {};
+    server.use(
+      http.post('/api/leads', async ({ request }) => {
+        body = await request.json();
+        return HttpResponse.json({ id: 'lead-new' });
+      })
+    );
+    render(<NewLead />);
+    await user.type(screen.getByPlaceholderText('שם מלא'), 'ליאת');
+    await user.click(screen.getByRole('checkbox', { name: 'השקעה' }));
+    await user.click(screen.getByRole('checkbox', { name: 'מסחרי' }));
+    // Toggle off the first one.
+    await user.click(screen.getByRole('checkbox', { name: 'השקעה' }));
+    await user.click(screen.getAllByRole('button', { name: /שמור ליד/ })[0]);
+    await waitFor(() => expect(body.purposes).toEqual(['COMMERCIAL']));
+  });
+});

--- a/tests/frontend/pages/NewProperty.test.tsx
+++ b/tests/frontend/pages/NewProperty.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { render, screen, userEvent, waitFor } from '../setup/test-utils';
+import { server } from '../setup/msw-server';
+import NewProperty from '@estia/frontend/pages/NewProperty.jsx';
+
+// NewProperty is a 1500-line wizard. These tests focus on the MLS-parity
+// fields (J4-J7 + J9) the current lane adds. The step-1 persistence is
+// already exercised elsewhere by the existing create test suite.
+
+describe('<NewProperty> — edit mode', () => {
+  it('hydrates J4-J7 + J9 fields from the property and shows them in step 2', async () => {
+    server.use(
+      http.get('/api/properties/:id', ({ params }) =>
+        HttpResponse.json({
+          property: {
+            id: params.id,
+            assetClass: 'RESIDENTIAL',
+            category: 'SALE',
+            street: 'הרצל 15',
+            city: 'רמלה',
+            marketingPrice: 2500000,
+            sqm: 120,
+            type: 'דירה',
+            rooms: 4,
+            // J4-J7 fields below:
+            condition: 'RENOVATED',
+            heatingTypes: ['gas', 'solar'],
+            halfRooms: 1,
+            masterBedroom: true,
+            bathrooms: 2,
+            toilets: 2,
+            furnished: true,
+            petFriendly: false,
+            doormenService: false,
+            gym: false,
+            pool: false,
+            gatedCommunity: false,
+            accessibility: true,
+            utilityRoom: false,
+            listingSource: 'yad2',
+            // J9 pipeline
+            stage: 'SIGNED_EXCLUSIVE',
+            agentCommissionPct: 2,
+            primaryAgentId: null,
+            exclusivityExpire: '2026-10-01T00:00:00.000Z',
+            sellerSeriousness: 'VERY',
+            brokerNotes: 'דחוף למכור',
+            imageList: [],
+          },
+        })
+      )
+    );
+    const user = userEvent.setup();
+    render(<NewProperty />, { route: '/properties/p1/edit', path: '/properties/:id/edit' });
+    // Wait for edit-mode hydration.
+    await waitFor(() => expect(screen.getByText(/עריכת נכס|עריכה — חבילת שיווק/)).toBeInTheDocument());
+    // Step-2 is the wider form. Click step-2 tab.
+    await user.click(screen.getByRole('button', { name: /חבילת שיווק/ }));
+    // J4 condition renders as a select with RENOVATED.
+    const conditionSelect = await screen.findByLabelText('מצב הנכס') as HTMLSelectElement;
+    expect(conditionSelect.value).toBe('RENOVATED');
+    // J9 stage via the pipeline block.
+    const stageSelect = screen.getByLabelText('שלב הנכס') as HTMLSelectElement;
+    expect(stageSelect.value).toBe('SIGNED_EXCLUSIVE');
+    // Broker notes hydrate.
+    expect((screen.getByLabelText('הערות מתווך') as HTMLTextAreaElement).value).toBe('דחוף למכור');
+  });
+
+  it('includes J4-J7 + J9 fields in the PATCH body on step-2 save', async () => {
+    let patchBody: Record<string, unknown> | null = null;
+    server.use(
+      http.get('/api/properties/:id', ({ params }) =>
+        HttpResponse.json({
+          property: {
+            id: params.id,
+            assetClass: 'RESIDENTIAL',
+            category: 'SALE',
+            street: 'הרצל 15', city: 'רמלה',
+            marketingPrice: 2500000, sqm: 120, type: 'דירה',
+            rooms: 4, heatingTypes: [],
+            imageList: [],
+          },
+        })
+      ),
+      http.patch('/api/properties/:id', async ({ request }) => {
+        patchBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ property: { id: 'p1' } });
+      })
+    );
+    const user = userEvent.setup();
+    render(<NewProperty />, { route: '/properties/p1/edit', path: '/properties/:id/edit' });
+    await waitFor(() => expect(screen.getByText(/עריכת נכס|עריכה — חבילת שיווק/)).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: /חבילת שיווק/ }));
+    // Save via the in-form primary button. Multiple buttons share this
+    // label (desktop + sticky mobile bar); pick the first.
+    const saveButtons = await screen.findAllByRole('button', { name: /שמור שינויים/ });
+    await user.click(saveButtons[0]);
+    await waitFor(() => expect(patchBody).toBeTruthy());
+    // J4-J7
+    expect(patchBody!).toHaveProperty('condition');
+    expect(patchBody!).toHaveProperty('heatingTypes');
+    expect(patchBody!).toHaveProperty('bathrooms');
+    expect(patchBody!).toHaveProperty('toilets');
+    expect(patchBody!).toHaveProperty('listingSource');
+    expect(patchBody!).toHaveProperty('halfRooms');
+    expect(patchBody!).toHaveProperty('furnished');
+    // J9
+    expect(patchBody!).toHaveProperty('stage');
+    expect(patchBody!).toHaveProperty('agentCommissionPct');
+    expect(patchBody!).toHaveProperty('exclusivityExpire');
+    expect(patchBody!).toHaveProperty('sellerSeriousness');
+    expect(patchBody!).toHaveProperty('brokerNotes');
+  });
+
+  it('toggles a heating type when the checkbox is clicked', async () => {
+    server.use(
+      http.get('/api/properties/:id', ({ params }) =>
+        HttpResponse.json({
+          property: {
+            id: params.id,
+            assetClass: 'RESIDENTIAL', category: 'SALE',
+            street: 'הרצל 15', city: 'רמלה',
+            marketingPrice: 2500000, sqm: 120, type: 'דירה',
+            rooms: 4, heatingTypes: [],
+            imageList: [],
+          },
+        })
+      )
+    );
+    const user = userEvent.setup();
+    render(<NewProperty />, { route: '/properties/p1/edit', path: '/properties/:id/edit' });
+    await waitFor(() => expect(screen.getByText(/עריכת נכס|עריכה — חבילת שיווק/)).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: /חבילת שיווק/ }));
+    const gasCheckbox = await screen.findByRole('checkbox', { name: 'גז' });
+    expect(gasCheckbox).not.toBeChecked();
+    await user.click(gasCheckbox);
+    expect(gasCheckbox).toBeChecked();
+  });
+});

--- a/tests/frontend/pages/Office.test.tsx
+++ b/tests/frontend/pages/Office.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { render, screen, userEvent, waitFor } from '../setup/test-utils';
+import { server } from '../setup/msw-server';
+import Office from '@estia/frontend/pages/Office.jsx';
+
+const OWNER = {
+  id: 'test-agent-1',
+  email: 'agent.demo@estia.app',
+  role: 'OWNER',
+  displayName: 'יוסי כהן',
+  slug: 'יוסי-כהן',
+  phone: '050-1234567',
+  avatarUrl: null,
+  agentProfile: { agency: 'Acme', title: '', bio: '' },
+  customerProfile: null,
+  hasCompletedTutorial: true,
+  firstLoginPlatform: 'web',
+};
+
+function asOwner() {
+  server.use(http.get('/api/me', () => HttpResponse.json({ user: OWNER })));
+}
+
+describe('<Office>', () => {
+  it('as OWNER with no office, shows the create form', async () => {
+    asOwner();
+    render(<Office />);
+    expect(await screen.findByRole('heading', { name: 'משרד' })).toBeInTheDocument();
+    expect(screen.getByLabelText('שם המשרד')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /צור משרד/ })).toBeInTheDocument();
+  });
+
+  it('creating an office POSTs and reloads', async () => {
+    asOwner();
+    const user = userEvent.setup();
+    let posted: unknown = null;
+    server.use(
+      http.post('/api/office', async ({ request }) => {
+        posted = await request.json();
+        // After creation, swap getOffice to return the new office.
+        server.use(
+          http.get('/api/office', () =>
+            HttpResponse.json({
+              office: { id: 'o1', name: 'נדלן הגולן' },
+              members: [{ id: OWNER.id, email: OWNER.email, displayName: OWNER.displayName, role: 'OWNER' }],
+            })
+          )
+        );
+        return HttpResponse.json({ office: { id: 'o1', name: 'נדלן הגולן' } });
+      })
+    );
+    render(<Office />);
+    const input = await screen.findByLabelText('שם המשרד');
+    await user.type(input, 'נדלן הגולן');
+    await user.click(screen.getByRole('button', { name: /צור משרד/ }));
+    await waitFor(() => expect(posted).toBeTruthy());
+    expect((posted as { name: string }).name).toBe('נדלן הגולן');
+  });
+
+  it('renders the office name + members when the office exists', async () => {
+    asOwner();
+    server.use(
+      http.get('/api/office', () =>
+        HttpResponse.json({
+          office: { id: 'o1', name: 'נדלן הגולן' },
+          members: [
+            { id: 'u1', email: 'owner@estia.app',   displayName: 'יוסי', role: 'OWNER' },
+            { id: 'u2', email: 'member@estia.app',  displayName: 'דני',  role: 'MEMBER' },
+          ],
+        })
+      )
+    );
+    render(<Office />);
+    expect(await screen.findByRole('heading', { name: 'נדלן הגולן' })).toBeInTheDocument();
+    expect(screen.getByText('יוסי')).toBeInTheDocument();
+    expect(screen.getByText('דני')).toBeInTheDocument();
+    expect(screen.getByLabelText(/הסר את דני/)).toBeInTheDocument();
+  });
+
+  it('invite form looks up the agent by email and POSTs the userId', async () => {
+    asOwner();
+    const user = userEvent.setup();
+    let invited: unknown = null;
+    server.use(
+      http.get('/api/office', () =>
+        HttpResponse.json({
+          office: { id: 'o1', name: 'Acme' },
+          members: [{ id: 'u1', email: 'owner@estia.app', displayName: 'יוסי', role: 'OWNER' }],
+        })
+      ),
+      http.get('/api/transfers/agents/search', () =>
+        HttpResponse.json({ agent: { id: 'u9', email: 'new@estia.app', displayName: 'חדש' } })
+      ),
+      http.post('/api/office/members', async ({ request }) => {
+        invited = await request.json();
+        return HttpResponse.json({ member: { id: 'm9', userId: 'u9', role: 'MEMBER' } });
+      })
+    );
+    render(<Office />);
+    const emailInput = await screen.findByLabelText('אימייל הסוכן');
+    await user.type(emailInput, 'new@estia.app');
+    await user.click(screen.getByRole('button', { name: /הזמן/ }));
+    await waitFor(() => expect(invited).toBeTruthy());
+    expect((invited as { userId: string }).userId).toBe('u9');
+  });
+});

--- a/tests/frontend/pages/PropertyDetail.test.tsx
+++ b/tests/frontend/pages/PropertyDetail.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { render, screen, userEvent, waitFor } from '../setup/test-utils';
+import { server } from '../setup/msw-server';
+import PropertyDetail from '@estia/frontend/pages/PropertyDetail.jsx';
+
+// happy-dom walks iframe src. The page embeds a Google Maps iframe —
+// stub it so the "unhandled request" MSW guard doesn't abort the test.
+beforeEach(() => {
+  server.use(
+    http.get('https://www.google.com/maps', () => new HttpResponse('', { status: 200 })),
+  );
+});
+
+const propertyFixture = {
+  id: 'p1',
+  agentId: 'test-agent-1',
+  assetClass: 'RESIDENTIAL',
+  category: 'SALE',
+  street: 'הרצל 15',
+  city: 'רמלה',
+  marketingPrice: 2500000,
+  sqm: 120,
+  type: 'דירה',
+  rooms: 4,
+  stage: 'IN_PROGRESS',
+  agentCommissionPct: 2,
+  sellerSeriousness: 'MEDIUM',
+  brokerNotes: '',
+  images: [],
+  imageList: [],
+  videos: [],
+  marketingActions: {},
+};
+
+function renderDetail() {
+  return render(<PropertyDetail />, {
+    route: '/properties/p1',
+    path: '/properties/:id',
+  });
+}
+
+describe('<PropertyDetail> — MLS parity wiring', () => {
+  it('shows the pipeline / adverts / assignees / matching / tags / activity / reminders cards', async () => {
+    server.use(
+      http.get('/api/properties/:id', () =>
+        HttpResponse.json({ property: propertyFixture })
+      )
+    );
+    renderDetail();
+    await waitFor(() => expect(screen.getByRole('heading', { name: /הרצל 15/ })).toBeInTheDocument());
+    expect(screen.getByText('צנרת תיווך')).toBeInTheDocument();
+    expect(screen.getByText('מודעות פרסום')).toBeInTheDocument();
+    expect(screen.getByText('שותפים לנכס')).toBeInTheDocument();
+    expect(screen.getByText('לקוחות תואמים')).toBeInTheDocument();
+    // "תגיות" appears as both the card title and the TagPicker stub label;
+    // either is proof the card rendered.
+    expect(screen.getAllByText('תגיות').length).toBeGreaterThan(0);
+    expect(screen.getByText('תזכורות')).toBeInTheDocument();
+    expect(screen.getByText('פעילות')).toBeInTheDocument();
+  });
+
+  it('opens the pipeline slide-in panel with the inline editor', async () => {
+    server.use(
+      http.get('/api/properties/:id', () =>
+        HttpResponse.json({ property: propertyFixture })
+      )
+    );
+    const user = userEvent.setup();
+    renderDetail();
+    await waitFor(() => expect(screen.getByRole('heading', { name: /הרצל 15/ })).toBeInTheDocument());
+    // The card's action has an aria-label "ערוך צנרת תיווך"; panel opens
+    // with the PropertyPipelineBlock.
+    await user.click(screen.getByRole('button', { name: 'ערוך צנרת תיווך' }));
+    // Block heading comes from the section aria-label; its fields render
+    // with the Hebrew label map.
+    await waitFor(() => expect(screen.getByLabelText('שלב הנכס')).toBeInTheDocument());
+    expect(screen.getByLabelText('הערות מתווך')).toBeInTheDocument();
+  });
+
+  it('opens the adverts panel and submits a draft advert', async () => {
+    let postBody: Record<string, unknown> | null = null;
+    server.use(
+      http.get('/api/properties/:id', () =>
+        HttpResponse.json({ property: propertyFixture })
+      ),
+      http.post('/api/properties/:id/adverts', async ({ request }) => {
+        postBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ advert: { id: 'new-1', ...postBody } });
+      })
+    );
+    const user = userEvent.setup();
+    renderDetail();
+    await waitFor(() => expect(screen.getByRole('heading', { name: /הרצל 15/ })).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: 'נהל מודעות פרסום' }));
+    // Panel content: click the primary CTA in the empty state.
+    const newButtons = await screen.findAllByRole('button', { name: /מודעה חדשה/ });
+    await user.click(newButtons[0]);
+    await user.selectOptions(screen.getByLabelText('ערוץ המודעה'), 'FACEBOOK');
+    await user.click(screen.getByRole('button', { name: 'שמור מודעה' }));
+    await waitFor(() => expect(postBody).toBeTruthy());
+    expect(postBody!.channel).toBe('FACEBOOK');
+  });
+
+  it('opens the assignees panel and lists existing ones from the API', async () => {
+    server.use(
+      http.get('/api/properties/:id', () =>
+        HttpResponse.json({ property: propertyFixture })
+      ),
+      http.get('/api/properties/:id/assignees', () =>
+        HttpResponse.json({
+          items: [{
+            userId: 'u2', role: 'CO_AGENT',
+            user: { id: 'u2', displayName: 'שותפה', email: 'p@estia.app', role: 'AGENT' },
+          }],
+        })
+      )
+    );
+    const user = userEvent.setup();
+    renderDetail();
+    await waitFor(() => expect(screen.getByRole('heading', { name: /הרצל 15/ })).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: 'נהל שותפים לנכס' }));
+    await waitFor(() => expect(screen.getByText('שותפה')).toBeInTheDocument());
+  });
+});

--- a/tests/frontend/pages/Reminders.test.tsx
+++ b/tests/frontend/pages/Reminders.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { render, screen, userEvent, waitFor } from '../setup/test-utils';
+import { server } from '../setup/msw-server';
+import Reminders from '@estia/frontend/pages/Reminders.jsx';
+
+describe('<Reminders>', () => {
+  it('renders the heading, inline form and the three status tabs', async () => {
+    render(<Reminders />);
+    expect(await screen.findByRole('heading', { name: 'תזכורות' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /פתוחות/ })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /הושלמו/ })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /בוטלו/ })).toBeInTheDocument();
+    expect(screen.getByLabelText('תיאור תזכורת')).toBeInTheDocument();
+  });
+
+  it('shows the EmptyState when the list is empty', async () => {
+    render(<Reminders />);
+    await waitFor(() => {
+      expect(screen.getByText('אין תזכורות פתוחות')).toBeInTheDocument();
+    });
+  });
+
+  it('filters by status when switching tabs', async () => {
+    const user = userEvent.setup();
+    const seen: string[] = [];
+    server.use(
+      http.get('/api/reminders', ({ request }) => {
+        const url = new URL(request.url);
+        seen.push(url.searchParams.get('status') ?? '');
+        return HttpResponse.json({ items: [] });
+      })
+    );
+    render(<Reminders />);
+    await waitFor(() => expect(seen).toContain('PENDING'));
+    await user.click(screen.getByRole('tab', { name: /הושלמו/ }));
+    await waitFor(() => expect(seen).toContain('COMPLETED'));
+    await user.click(screen.getByRole('tab', { name: /בוטלו/ }));
+    await waitFor(() => expect(seen).toContain('CANCELLED'));
+  });
+
+  it('creates a reminder via the inline form and POSTs to /api/reminders', async () => {
+    const user = userEvent.setup();
+    let posted: unknown = null;
+    server.use(
+      http.post('/api/reminders', async ({ request }) => {
+        posted = await request.json();
+        return HttpResponse.json({
+          reminder: {
+            id: 'rem-1', title: 'שיחה', status: 'PENDING', dueAt: null,
+            notes: null, leadId: null, propertyId: null, customerId: null,
+          },
+        });
+      })
+    );
+    render(<Reminders />);
+    const titleInput = await screen.findByLabelText('תיאור תזכורת');
+    await user.type(titleInput, 'שיחה');
+    await user.click(screen.getByRole('button', { name: /הוסף תזכורת/ }));
+    await waitFor(() => expect(posted).toBeTruthy());
+    expect((posted as { title: string }).title).toBe('שיחה');
+  });
+
+  it('calls the complete endpoint when clicking הושלם on a pending reminder', async () => {
+    const user = userEvent.setup();
+    let completedId: string | null = null;
+    server.use(
+      http.get('/api/reminders', () =>
+        HttpResponse.json({
+          items: [{
+            id: 'rem-1', title: 'להתקשר',
+            notes: null, dueAt: null, status: 'PENDING',
+            leadId: null, propertyId: null, customerId: null,
+            completedAt: null, cancelledAt: null,
+          }],
+        })
+      ),
+      http.post('/api/reminders/:id/complete', ({ params }) => {
+        completedId = params.id as string;
+        return HttpResponse.json({
+          reminder: { id: params.id, status: 'COMPLETED' },
+        });
+      })
+    );
+    render(<Reminders />);
+    const completeBtn = await screen.findByRole('button', { name: /סמן כהושלם/ });
+    await user.click(completeBtn);
+    await waitFor(() => expect(completedId).toBe('rem-1'));
+  });
+});

--- a/tests/frontend/pages/Reports.test.tsx
+++ b/tests/frontend/pages/Reports.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { render, screen, userEvent, waitFor } from '../setup/test-utils';
+import { server } from '../setup/msw-server';
+import Reports from '@estia/frontend/pages/Reports.jsx';
+
+describe('<Reports>', () => {
+  it('renders the page heading + default counts once endpoints resolve', async () => {
+    render(<Reports />);
+    expect(await screen.findByRole('heading', { name: 'דוחות' })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('נכסים חדשים')).toBeInTheDocument();
+    });
+  });
+
+  it('surfaces the populated counts from each report endpoint', async () => {
+    server.use(
+      http.get('/api/reports/new-properties', () =>
+        HttpResponse.json({ items: [], count: 4 })
+      ),
+      http.get('/api/reports/new-customers', () =>
+        HttpResponse.json({ items: [], count: 7 })
+      ),
+      http.get('/api/reports/deals', () =>
+        HttpResponse.json({
+          items: [], count: 2, totalCommission: 125_000,
+          byStatus: { OPEN: 1, WON: 1 },
+        })
+      ),
+      http.get('/api/reports/viewings', () =>
+        HttpResponse.json({ items: [], count: 9 })
+      ),
+      http.get('/api/reports/marketing-actions', () =>
+        HttpResponse.json({ items: [], count: 3 })
+      ),
+    );
+    render(<Reports />);
+    await waitFor(() => expect(screen.getByText('4')).toBeInTheDocument());
+    expect(screen.getByText('7')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('9')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+    // Total commission tile sub-line
+    expect(screen.getByText(/עמלה כוללת/)).toBeInTheDocument();
+    // byStatus breakdown rendered
+    expect(await screen.findByRole('heading', { name: 'עסקאות לפי סטטוס' })).toBeInTheDocument();
+    expect(screen.getByText('פתוחה')).toBeInTheDocument();
+    expect(screen.getByText('נסגרה')).toBeInTheDocument();
+  });
+
+  it('changing the date range refires the endpoints with from/to', async () => {
+    const user = userEvent.setup();
+    const seen: string[] = [];
+    server.use(
+      http.get('/api/reports/new-properties', ({ request }) => {
+        const url = new URL(request.url);
+        seen.push(`${url.searchParams.get('from') ?? ''}|${url.searchParams.get('to') ?? ''}`);
+        return HttpResponse.json({ items: [], count: 0 });
+      })
+    );
+    render(<Reports />);
+    await waitFor(() => expect(seen.length).toBeGreaterThan(0));
+    const initial = seen.length;
+    const fromInput = screen.getByLabelText('מתאריך');
+    await user.type(fromInput, '2026-01-01');
+    // Change should trigger a refetch.
+    await waitFor(() => expect(seen.length).toBeGreaterThan(initial));
+    expect(seen.some((s) => s.startsWith('2026-01-01'))).toBe(true);
+  });
+
+  it('renders CSV export anchors that point at api.exportUrl for each kind', () => {
+    render(<Reports />);
+    const propsA = screen.getByTestId('csv-properties') as HTMLAnchorElement;
+    const leadsA = screen.getByTestId('csv-leads') as HTMLAnchorElement;
+    const dealsA = screen.getByTestId('csv-deals') as HTMLAnchorElement;
+    expect(propsA.getAttribute('href')).toBe('/api/reports/export/properties.csv');
+    expect(leadsA.getAttribute('href')).toBe('/api/reports/export/leads.csv');
+    expect(dealsA.getAttribute('href')).toBe('/api/reports/export/deals.csv');
+    expect(propsA).toHaveAttribute('download');
+  });
+});

--- a/tests/frontend/pages/TagSettings.test.tsx
+++ b/tests/frontend/pages/TagSettings.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { render, screen, userEvent, waitFor } from '../setup/test-utils';
+import { server } from '../setup/msw-server';
+import TagSettings from '@estia/frontend/pages/TagSettings.jsx';
+
+describe('<TagSettings>', () => {
+  it('renders the page heading and inline create form', async () => {
+    render(<TagSettings />);
+    expect(await screen.findByRole('heading', { name: 'תגיות' })).toBeInTheDocument();
+    expect(screen.getByLabelText('שם התגית')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /הוסף תגית/ })).toBeInTheDocument();
+  });
+
+  it('shows the empty state when there are no tags', async () => {
+    render(<TagSettings />);
+    await waitFor(() => {
+      expect(screen.getByText('עדיין אין תגיות')).toBeInTheDocument();
+    });
+  });
+
+  it('creating a tag POSTs the name + scope', async () => {
+    const user = userEvent.setup();
+    let posted: unknown = null;
+    server.use(
+      http.post('/api/tags', async ({ request }) => {
+        posted = await request.json();
+        return HttpResponse.json({
+          tag: { id: 't1', name: 'VIP', color: '#c9a14a', scope: 'LEAD' },
+        });
+      })
+    );
+    render(<TagSettings />);
+    const nameInput = await screen.findByLabelText('שם התגית');
+    await user.type(nameInput, 'VIP');
+    await user.selectOptions(screen.getByLabelText('תחום תגית'), 'LEAD');
+    await user.click(screen.getByRole('button', { name: /הוסף תגית/ }));
+    await waitFor(() => expect(posted).toBeTruthy());
+    const body = posted as { name: string; scope: string };
+    expect(body.name).toBe('VIP');
+    expect(body.scope).toBe('LEAD');
+  });
+
+  it('renders existing tags with an edit + delete button per row', async () => {
+    server.use(
+      http.get('/api/tags', () =>
+        HttpResponse.json({
+          items: [
+            { id: 't1', name: 'VIP',      color: '#ff0000', scope: 'LEAD' },
+            { id: 't2', name: 'פרימיום', color: '#00ff00', scope: 'PROPERTY' },
+          ],
+        })
+      )
+    );
+    render(<TagSettings />);
+    expect(await screen.findByText('VIP')).toBeInTheDocument();
+    expect(screen.getByText('פרימיום')).toBeInTheDocument();
+    expect(screen.getByLabelText('מחק: VIP')).toBeInTheDocument();
+    expect(screen.getByLabelText('ערוך: VIP')).toBeInTheDocument();
+  });
+
+  it('clicking delete opens a confirm dialog; confirming calls deleteTag', async () => {
+    const user = userEvent.setup();
+    let deletedId: string | null = null;
+    server.use(
+      http.get('/api/tags', () =>
+        HttpResponse.json({
+          items: [{ id: 't1', name: 'VIP', color: '#c9a14a', scope: 'ALL' }],
+        })
+      ),
+      http.delete('/api/tags/:id', ({ params }) => {
+        deletedId = params.id as string;
+        return HttpResponse.json({ ok: true });
+      })
+    );
+    render(<TagSettings />);
+    await user.click(await screen.findByLabelText('מחק: VIP'));
+    // ConfirmDialog renders in a Portal — look up from document.
+    const confirmBtn = await screen.findByRole('button', { name: 'מחק' });
+    await user.click(confirmBtn);
+    await waitFor(() => expect(deletedId).toBe('t1'));
+  });
+});

--- a/tests/frontend/setup/msw-handlers.ts
+++ b/tests/frontend/setup/msw-handlers.ts
@@ -105,4 +105,239 @@ export const defaultHandlers = [
   // Geo / address autocomplete (Photon + Nominatim proxies)
   http.get('/api/geo/autocomplete', () => HttpResponse.json({ items: [] })),
   http.get('/api/geo/reverse', () => HttpResponse.json({ address: null })),
+
+  // ─── MLS parity surface ───────────────────────────────────────────────
+  // Default handlers return empty / minimal shapes so component tests
+  // render their empty states cleanly. Tests that need populated data
+  // override with `server.use(...)`.
+
+  // Office (A1)
+  http.get('/api/office', () => HttpResponse.json({ office: null, members: [] })),
+  http.post('/api/office', async ({ request }) => {
+    const body = (await request.json().catch(() => ({}))) as { name?: string };
+    return HttpResponse.json({ office: { id: 'office-1', name: body?.name ?? 'משרד' } });
+  }),
+  http.patch('/api/office', () =>
+    HttpResponse.json({ office: { id: 'office-1', name: 'משרד' } })
+  ),
+  http.post('/api/office/members', () =>
+    HttpResponse.json({ member: { id: 'm1', userId: 'u1', role: 'MEMBER' } })
+  ),
+  http.delete('/api/office/members/:id', () => HttpResponse.json({ ok: true })),
+
+  // Tags (A2)
+  http.get('/api/tags', () => HttpResponse.json({ items: [] })),
+  http.post('/api/tags', async ({ request }) => {
+    const body = (await request.json().catch(() => ({}))) as {
+      name?: string; color?: string; scope?: string;
+    };
+    return HttpResponse.json({
+      tag: {
+        id: 'tag-1',
+        name: body?.name ?? 'תג',
+        color: body?.color ?? null,
+        scope: body?.scope ?? 'ALL',
+      },
+    });
+  }),
+  http.patch('/api/tags/:id', ({ params }) =>
+    HttpResponse.json({ tag: { id: params.id, name: 'תג', color: null, scope: 'ALL' } })
+  ),
+  http.delete('/api/tags/:id', () => HttpResponse.json({ ok: true })),
+  http.post('/api/tags/:id/assign', () => HttpResponse.json({ ok: true })),
+  http.delete('/api/tags/:id/assign/:entityType/:entityId', () =>
+    HttpResponse.json({ ok: true })
+  ),
+  http.get('/api/tags/for', () => HttpResponse.json({ items: [] })),
+
+  // Reminders (D1)
+  http.get('/api/reminders', () => HttpResponse.json({ items: [] })),
+  http.post('/api/reminders', async ({ request }) => {
+    const body = (await request.json().catch(() => ({}))) as {
+      title?: string; dueAt?: string; notes?: string;
+      leadId?: string; propertyId?: string; customerId?: string;
+    };
+    return HttpResponse.json({
+      reminder: {
+        id: 'rem-1',
+        title: body?.title ?? '',
+        notes: body?.notes ?? null,
+        dueAt: body?.dueAt ?? null,
+        status: 'PENDING',
+        completedAt: null,
+        cancelledAt: null,
+        leadId: body?.leadId ?? null,
+        propertyId: body?.propertyId ?? null,
+        customerId: body?.customerId ?? null,
+      },
+    });
+  }),
+  http.patch('/api/reminders/:id', ({ params }) =>
+    HttpResponse.json({ reminder: { id: params.id, status: 'PENDING' } })
+  ),
+  http.post('/api/reminders/:id/complete', ({ params }) =>
+    HttpResponse.json({
+      reminder: { id: params.id, status: 'COMPLETED', completedAt: new Date().toISOString() },
+    })
+  ),
+  http.post('/api/reminders/:id/cancel', ({ params }) =>
+    HttpResponse.json({
+      reminder: { id: params.id, status: 'CANCELLED', cancelledAt: new Date().toISOString() },
+    })
+  ),
+  http.delete('/api/reminders/:id', () => HttpResponse.json({ ok: true })),
+
+  // Lead search profiles (K4)
+  http.get('/api/leads/:leadId/search-profiles', () => HttpResponse.json({ items: [] })),
+  http.post('/api/leads/:leadId/search-profiles', ({ params }) =>
+    HttpResponse.json({ profile: { id: 'sp-1', leadId: params.leadId } })
+  ),
+  http.patch('/api/leads/:leadId/search-profiles/:id', ({ params }) =>
+    HttpResponse.json({ profile: { id: params.id, leadId: params.leadId } })
+  ),
+  http.delete('/api/leads/:leadId/search-profiles/:id', () =>
+    HttpResponse.json({ ok: true })
+  ),
+
+  // Matching (C3)
+  http.get('/api/leads/:id/matches', () => HttpResponse.json({ items: [] })),
+  http.get('/api/properties/:id/matching-customers', () => HttpResponse.json({ items: [] })),
+
+  // Property assignees (J10)
+  http.get('/api/properties/:id/assignees', () => HttpResponse.json({ items: [] })),
+  http.post('/api/properties/:id/assignees', ({ params }) =>
+    HttpResponse.json({
+      assignee: {
+        propertyId: params.id,
+        userId: 'u1',
+        role: 'CO_AGENT',
+        assignedAt: new Date().toISOString(),
+        user: { id: 'u1', displayName: 'שותף', email: 'partner@estia.app', role: 'AGENT' },
+      },
+    })
+  ),
+  http.delete('/api/properties/:id/assignees/:userId', () =>
+    HttpResponse.json({ ok: true })
+  ),
+
+  // Adverts (F1)
+  http.get('/api/properties/:propertyId/adverts', () => HttpResponse.json({ items: [] })),
+  http.post('/api/properties/:propertyId/adverts', ({ params }) =>
+    HttpResponse.json({
+      advert: {
+        id: 'ad-1',
+        agentId: DEMO_AGENT.id,
+        propertyId: params.propertyId,
+        channel: 'YAD2',
+        status: 'DRAFT',
+        title: null,
+        body: null,
+        publishedPrice: null,
+        externalUrl: null,
+        externalId: null,
+        publishedAt: null,
+        expiresAt: null,
+      },
+    })
+  ),
+  http.patch('/api/adverts/:id', ({ params }) =>
+    HttpResponse.json({ advert: { id: params.id, status: 'DRAFT' } })
+  ),
+  http.delete('/api/adverts/:id', () => HttpResponse.json({ ok: true })),
+
+  // Global search (H1)
+  http.get('/api/search', ({ request }) => {
+    const url = new URL(request.url);
+    return HttpResponse.json({
+      query: url.searchParams.get('q') ?? '',
+      total: 0,
+      properties: [],
+      leads: [],
+      owners: [],
+      deals: [],
+    });
+  }),
+
+  // Activity (H3)
+  http.get('/api/activity', () => HttpResponse.json({ items: [] })),
+
+  // Reports (E1)
+  http.get('/api/reports/new-properties', () => HttpResponse.json({ items: [], count: 0 })),
+  http.get('/api/reports/new-customers', () => HttpResponse.json({ items: [], count: 0 })),
+  http.get('/api/reports/viewings', () => HttpResponse.json({ items: [], count: 0 })),
+  http.get('/api/reports/marketing-actions', () =>
+    HttpResponse.json({ items: [], count: 0 })
+  ),
+  http.get('/api/reports/deals', () =>
+    HttpResponse.json({ items: [], count: 0, totalCommission: 0, byStatus: {} })
+  ),
+
+  // CSV export (B5) — returns text/csv so fetch.text() works; api.exportUrl
+  // itself never fetches, but MSW still needs a handler for anything that
+  // does (e.g. a component fetching the CSV blob directly).
+  http.get('/api/reports/export/:kind.csv', () =>
+    new HttpResponse('id,name\n', {
+      status: 200,
+      headers: { 'Content-Type': 'text/csv; charset=utf-8' },
+    })
+  ),
+
+  // Neighborhoods (G1)
+  http.get('/api/neighborhoods', () => HttpResponse.json({ items: [] })),
+  http.post('/api/neighborhoods', async ({ request }) => {
+    const body = (await request.json().catch(() => ({}))) as {
+      city?: string; name?: string; aliases?: string[];
+    };
+    return HttpResponse.json({
+      neighborhood: {
+        id: 'nb-1',
+        city: body?.city ?? '',
+        name: body?.name ?? '',
+        aliases: body?.aliases ?? [],
+      },
+    });
+  }),
+
+  // Saved searches (B3)
+  http.get('/api/saved-searches', () => HttpResponse.json({ items: [] })),
+  http.post('/api/saved-searches', async ({ request }) => {
+    const body = (await request.json().catch(() => ({}))) as {
+      entityType?: string; name?: string; filters?: unknown;
+    };
+    return HttpResponse.json({
+      savedSearch: {
+        id: 'ss-1',
+        agentId: DEMO_AGENT.id,
+        entityType: body?.entityType ?? 'PROPERTY',
+        name: body?.name ?? '',
+        filters: body?.filters ?? {},
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+    });
+  }),
+  http.patch('/api/saved-searches/:id', ({ params }) =>
+    HttpResponse.json({ savedSearch: { id: params.id } })
+  ),
+  http.delete('/api/saved-searches/:id', () => HttpResponse.json({ ok: true })),
+
+  // Favorites (B4)
+  http.get('/api/favorites', () => HttpResponse.json({ items: [] })),
+  http.post('/api/favorites', async ({ request }) => {
+    const body = (await request.json().catch(() => ({}))) as {
+      entityType?: string; entityId?: string;
+    };
+    return HttpResponse.json({
+      favorite: {
+        id: 'fav-1',
+        agentId: DEMO_AGENT.id,
+        entityType: body?.entityType ?? 'PROPERTY',
+        entityId: body?.entityId ?? '',
+        createdAt: new Date().toISOString(),
+      },
+    });
+  }),
+  http.delete('/api/favorites/:entityType/:entityId', () =>
+    HttpResponse.json({ ok: true })
+  ),
 ];

--- a/tests/unit/frontend/api.test.js
+++ b/tests/unit/frontend/api.test.js
@@ -1,0 +1,90 @@
+// Typo canary — asserts every MLS-parity api.* method name exists on
+// the exported `api` object. If someone renames a method (e.g. drops
+// `leadMatches` in favour of `listLeadMatches`), this test breaks
+// *before* every dependent page starts throwing at runtime.
+//
+// Intentionally just shape-checks — no network calls, no MSW. The
+// point is to catch name drift across the ~40 methods the MLS UI
+// agents depend on.
+
+import { describe, it, expect } from 'vitest';
+import { api } from '../../../frontend/src/lib/api.js';
+
+const MLS_API_METHODS = [
+  // Office (A1)
+  'getOffice',
+  'createOffice',
+  'updateOffice',
+  'addOfficeMember',
+  'removeOfficeMember',
+  // Tags (A2)
+  'listTags',
+  'createTag',
+  'updateTag',
+  'deleteTag',
+  'assignTag',
+  'unassignTag',
+  'listAssignedTags',
+  // Reminders (D1)
+  'listReminders',
+  'createReminder',
+  'updateReminder',
+  'completeReminder',
+  'cancelReminder',
+  'deleteReminder',
+  // LeadSearchProfile (K4)
+  'listLeadSearchProfiles',
+  'createLeadSearchProfile',
+  'updateLeadSearchProfile',
+  'deleteLeadSearchProfile',
+  // Matching (C3)
+  'leadMatches',
+  'propertyMatchingCustomers',
+  // Assignees (J10)
+  'listPropertyAssignees',
+  'addPropertyAssignee',
+  'removePropertyAssignee',
+  // Adverts (F1)
+  'listAdverts',
+  'createAdvert',
+  'updateAdvert',
+  'deleteAdvert',
+  // Search (H1)
+  'globalSearch',
+  // Activity (H3)
+  'listActivity',
+  // Reports (E1)
+  'reportNewProperties',
+  'reportNewCustomers',
+  'reportDeals',
+  'reportViewings',
+  'reportMarketingActions',
+  'exportUrl',
+  // Neighborhoods (G1)
+  'listNeighborhoods',
+  'createNeighborhood',
+  // SavedSearch (B3)
+  'listSavedSearches',
+  'createSavedSearch',
+  'updateSavedSearch',
+  'deleteSavedSearch',
+  // Favorites (B4)
+  'listFavorites',
+  'addFavorite',
+  'removeFavorite',
+];
+
+describe('api client — MLS parity surface', () => {
+  it.each(MLS_API_METHODS)('exposes api.%s as a function', (name) => {
+    expect(api[name], `api.${name} is missing`).toBeTypeOf('function');
+  });
+
+  it('exportUrl returns a CSV URL string (not a fetch)', () => {
+    // Unlike every other method on the api object, exportUrl is a
+    // URL builder — it must not hit the network. Asserts both "it
+    // stayed sync" and "the path matches the backend's route".
+    const url = api.exportUrl('properties');
+    expect(typeof url).toBe('string');
+    expect(url).toMatch(/\/reports\/export\/properties\.csv$/);
+  });
+});


### PR DESCRIPTION
## Summary

Wires the UI for every MLS-parity backend endpoint that shipped in the
earlier `feat/mls-parity` branch. Built via five parallel worktree
agents + one shared-infra agent, merged in dependency order.

**New pages:** `/reports`, `/activity`, `/reminders`, `/office`, `/settings/tags`.

**Extended pages:** `Customers` (filter drawer + saved searches + favorite stars), `NewLead` / `CustomerDetail` (K1 contact fields, K2 admin block, L1 leadStatus, K4 search profiles, tag picker, reminders, matching properties, activity timeline), `NewProperty` / `PropertyDetail` (J4–J7 extras, J9 pipeline block, F1 adverts, J10 assignees, tag picker, reminders, matching customers, activity timeline), `Layout` + `CommandPalette` + `MobileMoreSheet` (H1 global search, management nav, favorites strip).

**New shared primitives:** `TagPicker`, `RemindersPanel`, `MatchingList`, `ActivityPanel`, `LeadSearchProfilesEditor`, `CustomerFiltersPanel`, `SavedSearchMenu`, `FavoriteStar`, `DateRangePicker`, `PropertyPipelineBlock`, `PropertyAssigneesPanel`, `AdvertsPanel` — plus `mlsLabels.js` as the single Hebrew-label source.

**Infrastructure:** 40+ new methods on `frontend/src/lib/api.js` with matching MSW default handlers in `tests/frontend/setup/msw-handlers.ts`.

## Test plan

- [ ] `npm run test:frontend` — 497 passed / 63 files (baseline 318 / 39). No deletions, no flakes.
- [ ] `npm run lint` (frontend) — 0 errors, 25 warnings (1 under baseline).
- [ ] Backend `tsc --noEmit` clean; `npm run test:integration` still 272/272.
- [ ] Manual dev-server walkthrough of `/customers` filter drawer → save search → favorite a row.
- [ ] Manual walkthrough of `/customers/:id` → attach tag, add reminder, create search profile, view matching properties.
- [ ] Manual walkthrough of `/properties/:id` → pipeline edit, add advert, add co-agent, view matching customers, view activity.
- [ ] Manual walkthrough of each new page (`/reports` with CSV export, `/activity` with entity filter, `/reminders` tabs, `/office` invite, `/settings/tags` CRUD).
- [ ] Cmd-K opens CommandPalette → typing triggers `/api/search` with grouped results.

## Known gaps (Phase 3 follow-up)

- **G1** neighborhoods autocomplete wire-up (backend live, no frontend consumer yet)
- **B2** dashboard repository-change counters
- Previously-deferred UI work: G2 neighborhood groups, J8 owner phones, J11 customer field-map, B6 print, B7 open-in-new-window, C4 seriousness override popover, F5 vCard QR, H2 quick-create FAB, L3 quick-lead description UI, F2 CMA PDF, F3 typed Agreements, F4 detail property report, H4 settings-index shell, K3 auto-match notification channels.

Purely additive — no destructive migrations, no breaking API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)