### PR TITLE
fix(build): unblock prod image builds (Dockerfile postinstall + watcher enum casts)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -25,9 +25,14 @@ COPY package.json package-lock.json ./
 # --no-save keeps the resulting node_modules consistent with the
 # lockfile for everything else.
 RUN echo "deps cachebust: $DEPS_CACHEBUST" \
-  && npm ci --no-audit --no-fund \
-  && npm install --no-audit --no-fund --no-save openai@6.34.0 @anthropic-ai/sdk@0.91.0 \
+  && npm ci --no-audit --no-fund --ignore-scripts \
+  && npm install --no-audit --no-fund --no-save --ignore-scripts openai@6.34.0 @anthropic-ai/sdk@0.91.0 \
   && node -e "require.resolve('openai'); require.resolve('@anthropic-ai/sdk'); console.log('deps ok')"
+# --ignore-scripts skips the backend/package.json `postinstall: prisma generate`
+# (added 2026-04-30 in f82e0c3). The prisma schema isn't COPY'd into the
+# deps stage — only the build stage has prisma/. The build stage's
+# explicit `npx prisma generate` covers that case; postinstall is for
+# local dev convenience.
 
 FROM base AS build
 COPY --from=deps /app/node_modules ./node_modules

--- a/services/market-metadata-watcher/src/tick.ts
+++ b/services/market-metadata-watcher/src/tick.ts
@@ -1,4 +1,9 @@
-import type { PrismaClient } from '@prisma/client';
+import type {
+  MarketListingKind,
+  MarketListingPosterType,
+  MarketListingStatus,
+  PrismaClient,
+} from '@prisma/client';
 import type { Logger } from 'pino';
 import { config } from './config.js';
 import { metadataHash, type HashableListing } from './hash.js';
@@ -165,9 +170,14 @@ export async function runWatcherTick(
             floor: item.floor,
             price: item.price,
             pricePerSqm: item.pricePerSqm,
-            kind: item.kind,
-            posterType: item.posterType,
-            status: item.status || 'active',
+            // HashableListing types these as `string | null` to keep the
+            // hash function generic; Prisma's enums are strict. Cast at
+            // the boundary — the source extractors emit only valid
+            // lowercase enum values ('forsale'|'rent', 'private'|'agency',
+            // 'active'|'removed'|'unknown').
+            kind: item.kind as MarketListingKind | null,
+            posterType: item.posterType as MarketListingPosterType | null,
+            status: (item.status || 'active') as MarketListingStatus,
             metadataHash: hash,
             // reactedAt deliberately left NULL — backend reactor
             // processes new rows on its 30s poll cadence.
@@ -201,9 +211,9 @@ export async function runWatcherTick(
                   floor: item.floor,
                   price: item.price,
                   pricePerSqm: item.pricePerSqm,
-                  kind: item.kind,
-                  posterType: item.posterType,
-                  status: item.status || existing.status,
+                  kind: item.kind as MarketListingKind | null,
+                  posterType: item.posterType as MarketListingPosterType | null,
+                  status: (item.status || existing.status) as MarketListingStatus,
                   metadataHash: hash,
                   // Reset reactor cursor on metadata change so the
                   // reactor re-evaluates against possibly-affected
@@ -220,7 +230,7 @@ export async function runWatcherTick(
               marketListingId: existing.id,
               price: item.price ?? null,
               pricePerSqm: item.pricePerSqm ?? null,
-              status: item.status || existing.status,
+              status: (item.status || existing.status) as MarketListingStatus,
               metadataHash: hash,
             },
           });


### PR DESCRIPTION
Two pre-existing build failures blocking the deploy of #312 (the perf-optimization PR).

1. backend/Dockerfile — the new postinstall hook in backend/package.json (added by f82e0c3) runs prisma generate during `npm ci` in the deps stage, but prisma/ isn't COPY'd until the build stage. Adds --ignore-scripts to the deps-stage npm calls.

2. services/market-metadata-watcher/src/tick.ts — the watcher's Dockerfile generates Prisma client from the backend's strict-enum schema. tick.ts was passing string | null into enum-typed columns. Cast at the boundary.

Both fixes are surgical, additive, and required for any deploy off main.