### PR TITLE
perf(infra): 2 backend replicas + DNS round-robin + Grafana stack

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -171,11 +171,21 @@ jobs:
           echo "$GHCR_TOKEN" | sudo docker login ghcr.io -u token --password-stdin >/dev/null
           export ESTIA_TAG
           sudo -E docker compose -f docker-compose.prod.yml pull
-          sudo -E docker compose -f docker-compose.prod.yml up -d --remove-orphans
+          # PERF — 2026-05-01: scale backend to 2 replicas. Frontend
+          # nginx upstream uses Docker's embedded DNS resolver (see
+          # frontend/nginx.conf) so adding/removing replicas takes
+          # effect within ~10s without an nginx reload. The exec call
+          # below targets backend-1 explicitly to run prisma migrate
+          # deploy exactly once (not per-replica).
+          sudo -E docker compose -f docker-compose.prod.yml up -d \
+            --scale backend=2 --remove-orphans
           if [ "$SKIP_MIGRATIONS" = "true" ]; then
             echo 'skip_migrations=true — not running prisma migrate deploy'
           else
-            sudo -E docker compose -f docker-compose.prod.yml exec -T backend npx prisma migrate deploy
+            # `compose exec backend` doesn't work cleanly when service
+            # has >1 replica (compose picks one but logs a warning).
+            # Target backend-1 directly via container name.
+            sudo docker exec -e DATABASE_URL="$(sudo grep -E '^DATABASE_URL=' .env | cut -d= -f2- | tr -d '\"')" estia-new-backend-1 npx prisma migrate deploy
           fi
           echo "$ESTIA_TAG" | sudo tee .deployed_sha >/dev/null
           sudo docker image prune -af >/dev/null 2>&1 || true

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -26,7 +26,14 @@ services:
       # routes writes to S3. See docker-compose.yml header note.
       UPLOADS_DIR: /app/uploads
     ports:
-      - "${BACKEND_BIND_ADDR:-127.0.0.1}:${BACKEND_PORT:-6002}:4000"
+      # Port range so `docker compose up --scale backend=N` (PERF —
+      # 2026-05-01) auto-allocates a host-side port per replica. With
+      # a literal `:6002:4000`, the second replica fails to bind and
+      # only the first comes up. Range stays inside 127.0.0.1 so the
+      # backend remains internal-only — public traffic flows through
+      # the frontend nginx upstream `backend:4000` (which uses Docker's
+      # embedded DNS round-robin, see frontend/nginx.conf resolver).
+      - "${BACKEND_BIND_ADDR:-127.0.0.1}:${BACKEND_PORT_RANGE:-6002-6003}:4000"
     logging:
       driver: json-file
       options: { max-size: "20m", max-file: "5" }

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -29,6 +29,19 @@ server {
   client_max_body_size 120m;
   client_body_buffer_size 1m;
 
+  # PERF — Docker embedded DNS for runtime upstream resolution. Without
+  # this, nginx resolves `backend` ONCE at startup and pins to that IP
+  # forever, defeating `docker compose up --scale backend=N` round-robin.
+  # 127.0.0.11 is Docker's embedded resolver inside any user-defined
+  # network (which compose creates by default). `valid=10s` re-resolves
+  # at most every 10s — fast enough for replica adds, gentle on the
+  # resolver. ipv6=off skips AAAA lookups; Docker only emits A.
+  resolver 127.0.0.11 valid=1s ipv6=off;
+  # Variable reference forces nginx to resolve `backend` per-request
+  # against the resolver above, instead of caching one IP at startup.
+  # Each `proxy_pass` below uses `$api_backend` instead of a literal URL.
+  set $api_backend "http://backend:4000";
+
   # SEC-011 — defense-in-depth security headers. The `always` qualifier
   # makes nginx attach each header on 4xx/5xx responses too (without it,
   # a 502 from the backend ships unprotected, which is exactly when a
@@ -87,7 +100,7 @@ server {
   # because both branches `proxy_pass` to the same upstream — only the
   # buffering / body-size knobs differ.
   location ~ ^/api/.*/(images|videos|avatar|documents) {
-    proxy_pass http://backend:4000;
+    proxy_pass $api_backend;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";
@@ -102,7 +115,7 @@ server {
   }
 
   location /api/ {
-    proxy_pass http://backend:4000;
+    proxy_pass $api_backend;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";
@@ -129,7 +142,7 @@ server {
   # only matters for legacy rows + non-image documents until those are
   # backfilled.
   location /uploads/ {
-    proxy_pass http://backend:4000;
+    proxy_pass $api_backend;
     proxy_set_header Host $host;
     add_header Cache-Control "public, max-age=31536000, immutable";
   }

--- a/infra/monitoring/README.md
+++ b/infra/monitoring/README.md
@@ -1,0 +1,104 @@
+# Monitoring stack — Prometheus + postgres_exporter + node_exporter + Grafana
+
+Self-hosted observability for the Estia EC2 + RDS pair, brought up as
+a separate `docker compose` project alongside the main estia-new stack.
+
+## What it gives you
+
+- **Postgres connection pool** (active vs idle) on the RDS instance
+- **Slow / long-running query** metrics from `pg_stat_activity`
+- **EC2 host CPU, memory, disk, network**
+- **Postgres deadlocks, temp bytes/sec, transaction throughput**
+
+The Estia backend's pino slow-query log (>200ms warn) covers
+per-query specifics; this stack covers the system + pool view that
+correlates "the app is slow" with "Postgres is at 80% of its
+connection cap" or "EC2 swap usage just spiked".
+
+## Where it runs
+
+On the production EC2 itself, in `/home/ec2-user/estia-new/monitoring/`.
+Bound to `127.0.0.1` only — not publicly exposed. Access via SSH tunnel:
+
+```bash
+ssh -L 3000:127.0.0.1:3000 -L 9090:127.0.0.1:9090 \
+    -i ~/.ssh/tripzio.pem \
+    ec2-user@ec2-13-49-145-46.eu-north-1.compute.amazonaws.com
+# Then open http://localhost:3000  (Grafana)
+#         http://localhost:9090  (Prometheus, raw queries)
+```
+
+## First-run setup
+
+```bash
+ssh ec2-user@<host>
+cd /home/ec2-user/estia-new/monitoring
+
+# 1. Build a libpq-clean DSN from the backend's DATABASE_URL.
+#    The backend's DSN has Prisma-specific params (connection_limit,
+#    pool_timeout, schema=public) that postgres_exporter chokes on.
+DB_URL=$(sudo grep -E '^DATABASE_URL=' /home/ec2-user/estia-new/.env | cut -d= -f2- | tr -d '"')
+LIBPQ_DSN=$(python3 -c "
+from urllib.parse import urlsplit, parse_qsl, urlunsplit, urlencode
+u = urlsplit('$DB_URL')
+q = [(k,v) for k,v in parse_qsl(u.query) if k in ('sslmode',)]
+print(urlunsplit((u.scheme, u.netloc, u.path, urlencode(q), u.fragment)))
+")
+echo "DATA_SOURCE_NAME=$LIBPQ_DSN" | sudo tee .env >/dev/null
+
+# 2. Set a Grafana admin password
+echo "GRAFANA_ADMIN_PASSWORD=$(openssl rand -hex 12)" | sudo tee -a .env >/dev/null
+sudo chmod 600 .env
+
+# 3. Bring it up
+sudo docker compose -f docker-compose.monitoring.yml up -d
+
+# 4. Verify
+curl -s http://127.0.0.1:9187/metrics | head -5      # postgres_exporter
+curl -s http://127.0.0.1:9090/api/v1/targets         # prometheus targets
+curl -s http://127.0.0.1:3000/api/health             # grafana
+```
+
+The Grafana admin password is in `monitoring/.env` on the EC2:
+
+```bash
+sudo grep GRAFANA_ADMIN_PASSWORD /home/ec2-user/estia-new/monitoring/.env
+```
+
+## Provisioned dashboard
+
+After Grafana boots it auto-loads the `Estia / Estia — Overview` dashboard
+(`grafana/dashboards/estia-overview.json`). Includes:
+
+- Postgres connections by state (active / idle / idle-in-transaction / waiting)
+- Postgres connection count over time
+- Slowest currently-running query duration (seconds)
+- EC2 CPU %
+- EC2 memory used %
+- Disk used % (root)
+- Postgres deadlocks/sec
+- Postgres temp bytes/sec
+
+To add a custom dashboard, drop a JSON file into `grafana/dashboards/`
+on the host (path is bind-mounted) — Grafana picks it up within 30s.
+
+## Troubleshooting
+
+- `pg_up=0`: postgres_exporter can't reach RDS. Re-check `.env`'s
+  `DATA_SOURCE_NAME` is libpq-clean (no `connection_limit`, no
+  `schema=public`, no `pool_timeout`). Also verify the RDS security
+  group allows port 5432 from the EC2's IP.
+
+- `prometheus target node down`: `host.docker.internal` isn't resolving.
+  Linux Docker needs `extra_hosts: ["host.docker.internal:host-gateway"]`
+  on the prometheus service (already in the compose).
+
+- Wipe history: `docker volume rm monitoring_prometheus_data
+  monitoring_grafana_data` (will lose dashboards customized via UI;
+  the provisioned base dashboard re-loads from disk on next start).
+
+## Footprint
+
+Idle stack uses ~250MB RAM, <1% CPU on the EC2. Prometheus storage
+grows by ~50MB/day at the default 15s scrape interval; capped at
+30 days retention so steady-state ~1.5GB on disk.

--- a/infra/monitoring/docker-compose.monitoring.yml
+++ b/infra/monitoring/docker-compose.monitoring.yml
@@ -1,0 +1,103 @@
+# Monitoring stack — Prometheus + postgres_exporter + Grafana.
+#
+# Bound to 127.0.0.1 only; not publicly exposed. Access on EC2:
+#   ssh -L 3000:127.0.0.1:3000 ec2-user@<host>   # then http://localhost:3000
+#
+# Brought up with:
+#   sudo docker compose -f docker-compose.monitoring.yml up -d
+#
+# Joins the same network as the main estia-new stack so that
+# postgres_exporter can talk to RDS via the host (RDS is reachable
+# from any VPC peer; we use the same DATABASE_URL the backend uses).
+#
+# Storage: Prometheus + Grafana data live on named volumes; safe to
+# `down` and `up -d` without losing dashboards/history. Wipe history
+# with `docker volume rm monitoring_prometheus_data monitoring_grafana_data`.
+
+services:
+  prometheus:
+    image: prom/prometheus:v2.55.0
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:9090:9090"
+    # Linux Docker doesn't auto-resolve host.docker.internal — map it
+    # to the gateway IP so prometheus can scrape node_exporter (which
+    # runs in network_mode: host).
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=30d'
+      - '--web.console.libraries=/etc/prometheus/console_libraries'
+      - '--web.console.templates=/etc/prometheus/consoles'
+    logging:
+      driver: json-file
+      options: { max-size: "20m", max-file: "5" }
+
+  postgres_exporter:
+    image: prometheuscommunity/postgres-exporter:v0.15.0
+    restart: unless-stopped
+    # DATA_SOURCE_NAME comes from monitoring/.env (operator-provided),
+    # NOT from /home/ec2-user/estia-new/.env directly — the backend's
+    # DATABASE_URL contains Prisma-specific query params like
+    # connection_limit / pool_timeout that confuse libpq. The setup
+    # script (see infra/monitoring/README.md) strips those at install
+    # time and writes a libpq-clean DSN here.
+    env_file: ./.env
+    environment:
+      PG_EXPORTER_AUTO_DISCOVER_DATABASES: "false"
+      PG_EXPORTER_EXTEND_QUERY_PATH: ""
+    ports:
+      - "127.0.0.1:9187:9187"
+    logging:
+      driver: json-file
+      options: { max-size: "10m", max-file: "3" }
+
+  node_exporter:
+    # Host-level CPU / memory / disk / network metrics. Useful for
+    # correlating "the backend is slow" with "EC2 box is at 100% CPU".
+    image: prom/node-exporter:v1.8.2
+    restart: unless-stopped
+    pid: host
+    network_mode: host
+    volumes:
+      - /:/host:ro,rslave
+    command:
+      - '--path.rootfs=/host'
+      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
+    logging:
+      driver: json-file
+      options: { max-size: "10m", max-file: "3" }
+
+  grafana:
+    image: grafana/grafana:11.3.0
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:3000:3000"
+    environment:
+      # First-run admin password — can be reset later via the UI.
+      # Comes from monitoring.env (a small companion file the operator
+      # writes when bringing the stack up). If unset, Grafana defaults
+      # to admin/admin.
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_AUTH_ANONYMOUS_ENABLED: "false"
+      GF_INSTALL_PLUGINS: ""
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards-provisioned:ro
+    depends_on:
+      - prometheus
+      - postgres_exporter
+    logging:
+      driver: json-file
+      options: { max-size: "10m", max-file: "3" }
+
+volumes:
+  prometheus_data:
+  grafana_data:

--- a/infra/monitoring/grafana/dashboards/estia-overview.json
+++ b/infra/monitoring/grafana/dashboards/estia-overview.json
@@ -1,0 +1,82 @@
+{
+  "annotations": {"list": []},
+  "title": "Estia — Overview",
+  "uid": "estia-overview",
+  "version": 1,
+  "schemaVersion": 38,
+  "refresh": "30s",
+  "time": {"from": "now-3h", "to": "now"},
+  "timezone": "Asia/Jerusalem",
+  "tags": ["estia"],
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Postgres connections",
+      "id": 1,
+      "gridPos": {"x": 0, "y": 0, "w": 6, "h": 6},
+      "targets": [{"refId": "A", "expr": "pg_stat_activity_count{datname='estia'}"}],
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value", "graphMode": "area"},
+      "fieldConfig": {"defaults": {"thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 60}, {"color": "red", "value": 90}]}}}
+    },
+    {
+      "type": "stat",
+      "title": "Connections by state",
+      "id": 2,
+      "gridPos": {"x": 6, "y": 0, "w": 6, "h": 6},
+      "targets": [{"refId": "A", "expr": "sum by (state) (pg_stat_activity_count{datname='estia'})", "legendFormat": "{{state}}"}],
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value"}
+    },
+    {
+      "type": "timeseries",
+      "title": "Postgres connections over time",
+      "id": 3,
+      "gridPos": {"x": 0, "y": 6, "w": 12, "h": 8},
+      "targets": [{"refId": "A", "expr": "sum by (state) (pg_stat_activity_count{datname='estia'})", "legendFormat": "{{state}}"}]
+    },
+    {
+      "type": "timeseries",
+      "title": "Slowest queries (max duration of running query, s)",
+      "id": 4,
+      "gridPos": {"x": 12, "y": 0, "w": 12, "h": 8},
+      "targets": [{"refId": "A", "expr": "pg_stat_activity_max_tx_duration{datname='estia'}", "legendFormat": "max running tx (s)"}]
+    },
+    {
+      "type": "timeseries",
+      "title": "EC2 host CPU %",
+      "id": 5,
+      "gridPos": {"x": 12, "y": 8, "w": 12, "h": 8},
+      "targets": [{"refId": "A", "expr": "100 - (avg by (instance) (irate(node_cpu_seconds_total{mode='idle'}[5m])) * 100)", "legendFormat": "{{instance}}"}],
+      "fieldConfig": {"defaults": {"unit": "percent"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "EC2 host memory used %",
+      "id": 6,
+      "gridPos": {"x": 0, "y": 14, "w": 12, "h": 8},
+      "targets": [{"refId": "A", "expr": "100 * (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes))", "legendFormat": "{{instance}}"}],
+      "fieldConfig": {"defaults": {"unit": "percent"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Disk used % (root)",
+      "id": 7,
+      "gridPos": {"x": 12, "y": 14, "w": 12, "h": 8},
+      "targets": [{"refId": "A", "expr": "100 - (node_filesystem_avail_bytes{mountpoint='/'} / node_filesystem_size_bytes{mountpoint='/'} * 100)", "legendFormat": "/"}],
+      "fieldConfig": {"defaults": {"unit": "percent"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Postgres deadlocks / sec",
+      "id": 8,
+      "gridPos": {"x": 0, "y": 22, "w": 12, "h": 6},
+      "targets": [{"refId": "A", "expr": "rate(pg_stat_database_deadlocks{datname='estia'}[5m])", "legendFormat": "deadlocks/s"}]
+    },
+    {
+      "type": "timeseries",
+      "title": "Postgres temp bytes / sec",
+      "id": 9,
+      "gridPos": {"x": 12, "y": 22, "w": 12, "h": 6},
+      "targets": [{"refId": "A", "expr": "rate(pg_stat_database_temp_bytes{datname='estia'}[5m])", "legendFormat": "temp bytes/s"}]
+    }
+  ]
+}

--- a/infra/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/infra/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+providers:
+  - name: 'Estia provisioned'
+    orgId: 1
+    folder: 'Estia'
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards-provisioned

--- a/infra/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/infra/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true
+    jsonData:
+      timeInterval: '15s'

--- a/infra/monitoring/prometheus.yml
+++ b/infra/monitoring/prometheus.yml
@@ -1,0 +1,24 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: 'postgres'
+    static_configs:
+      - targets: ['postgres_exporter:9187']
+        labels:
+          db: 'estia-prod'
+
+  - job_name: 'node'
+    # node_exporter runs in network_mode: host so we hit it on the
+    # EC2's loopback as observed from another container. The
+    # `extra_hosts` in the compose maps `host.docker.internal` to the
+    # host's gateway IP on Linux.
+    static_configs:
+      - targets: ['host.docker.internal:9100']
+        labels:
+          host: 'estia-prod-ec2'


### PR DESCRIPTION
## Summary

Three pieces of infra work that landed live on prod during the 2026-05-01 perf sweep, captured here so future deploys carry them.

### 1. Backend scaled to 2 replicas
- `docker-compose.prod.yml`: backend ports become a range (`6002-6003:4000`) so `--scale backend=N` works
- `.github/workflows/deploy-prod.yml`: deploys now `--scale backend=2`; migrations target `estia-new-backend-1` directly (compose exec warns on multi-replica services)

### 2. nginx round-robin via Docker DNS
- `frontend/nginx.conf`: add `resolver 127.0.0.11 valid=1s ipv6=off` + variable `proxy_pass $api_backend` so nginx re-resolves `backend` per request instead of pinning to the first IP at startup
- Verified: 20× concurrent burst → 10/10 split between replicas

### 3. Self-hosted Grafana on EC2
- `infra/monitoring/`: prometheus + postgres_exporter + node_exporter + Grafana, bound to 127.0.0.1, accessed via SSH tunnel
- Provisioned dashboard with 9 panels (connections by state, slow query duration, CPU/mem/disk%, deadlocks, temp bytes/s)
- README in `infra/monitoring/README.md` covers first-run setup + access pattern

### Operator-side changes (already applied, not in repo)

- `/home/ec2-user/estia-new/.env`: `DATABASE_URL` now has `?connection_limit=20&pool_timeout=10` appended (was blocking backend startup since the f82e0c3 audit commit added that requirement)
- `/home/ec2-user/estia-new/monitoring/.env`: created with libpq-clean `DATA_SOURCE_NAME` for postgres_exporter and a Grafana admin password

## Test plan

- [x] 20× concurrent burst test split 10/10 between replicas
- [x] postgres_exporter scrapes RDS (`pg_stat_activity_count` returns real numbers)
- [x] Grafana auto-loads "Estia — Overview" dashboard
- [x] All 3 Prometheus targets up (node, postgres, prometheus)
- [ ] CI green
- [ ] Re-run perf benchmark to confirm 30/100 user numbers improved

🤖 Generated with [Claude Code](https://claude.com/claude-code)