### PR TITLE
perf+monitoring: 30-user follow-ups + admin monitoring page

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -178,7 +178,7 @@ jobs:
           # below targets backend-1 explicitly to run prisma migrate
           # deploy exactly once (not per-replica).
           sudo -E docker compose -f docker-compose.prod.yml up -d \
-            --scale backend=2 --remove-orphans
+            --scale backend=3 --remove-orphans
           if [ "$SKIP_MIGRATIONS" = "true" ]; then
             echo 'skip_migrations=true — not running prisma migrate deploy'
           else

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -258,4 +258,87 @@ export const registerAdminRoutes: FastifyPluginAsync = async (app) => {
       })),
     };
   });
+
+  // GET /api/admin/monitoring — live snapshot for the /admin/monitoring
+  // page. Reads pg_stat_activity / pg_stat_database directly via
+  // Prisma raw queries (the same source postgres_exporter scrapes), so
+  // it works even if the Prometheus stack is down. If PROMETHEUS_URL is
+  // set in env, it also pulls active firing alerts.
+  app.get('/monitoring', { onRequest: [app.requireAdmin] }, async () => {
+    const rows = await prisma.$queryRawUnsafe<Array<{ state: string | null; count: bigint }>>(
+      `SELECT state, count(*)::bigint AS count
+         FROM pg_stat_activity
+         WHERE datname = current_database()
+         GROUP BY state`,
+    );
+    const conn: Record<string, number> = {};
+    for (const r of rows) {
+      const k = (r.state || 'unknown').replace(/\s+/g, '_');
+      conn[k] = Number(r.count);
+    }
+
+    const longRow = await prisma.$queryRawUnsafe<Array<{ longest_seconds: number | null }>>(
+      `SELECT COALESCE(EXTRACT(EPOCH FROM max(now() - xact_start)), 0)::float AS longest_seconds
+         FROM pg_stat_activity
+         WHERE datname = current_database()
+           AND state IN ('active', 'idle in transaction')`,
+    );
+    const longestSec = Number(longRow[0]?.longest_seconds ?? 0);
+
+    const deadlocksRow = await prisma.$queryRawUnsafe<Array<{ deadlocks: bigint }>>(
+      `SELECT deadlocks::bigint AS deadlocks FROM pg_stat_database WHERE datname = current_database()`,
+    );
+    const deadlocksTotal = Number(deadlocksRow[0]?.deadlocks ?? 0);
+
+    const maxConnRow = await prisma.$queryRawUnsafe<Array<{ setting: string }>>(
+      `SHOW max_connections`,
+    );
+    const maxConnections = Number(maxConnRow[0]?.setting ?? 0);
+
+    let firingAlerts: Array<{ name: string; severity: string; summary: string; activeAt: string }> = [];
+    let promReachable = false;
+    if (process.env.PROMETHEUS_URL) {
+      try {
+        const r = await fetch(`${process.env.PROMETHEUS_URL.replace(/\/$/, '')}/api/v1/alerts`, {
+          signal: AbortSignal.timeout(2000),
+        });
+        if (r.ok) {
+          promReachable = true;
+          const j = (await r.json()) as { data?: { alerts?: Array<{ state: string; labels: Record<string, string>; annotations: Record<string, string>; activeAt?: string }> } };
+          firingAlerts = (j.data?.alerts || [])
+            .filter((a) => a.state === 'firing')
+            .map((a) => ({
+              name: a.labels?.alertname ?? '?',
+              severity: a.labels?.severity ?? 'unknown',
+              summary: a.annotations?.summary ?? '',
+              activeAt: a.activeAt ?? '',
+            }));
+        }
+      } catch { /* prometheus unreachable; degrade gracefully */ }
+    }
+
+    return {
+      capturedAt: new Date().toISOString(),
+      db: {
+        connections: {
+          total: Object.values(conn).reduce((a, b) => a + b, 0),
+          active: conn.active ?? 0,
+          idle: conn.idle ?? 0,
+          idle_in_transaction: conn.idle_in_transaction ?? 0,
+          waiting: conn.waiting ?? 0,
+        },
+        maxConnections,
+        longestRunningTxSeconds: longestSec,
+        deadlocksSinceBoot: deadlocksTotal,
+      },
+      alerts: {
+        prometheus_reachable: promReachable,
+        firing: firingAlerts,
+      },
+      links: {
+        grafana_local: 'http://localhost:3000',
+        prometheus_local: 'http://localhost:9090',
+      },
+    };
+  });
 };

--- a/backend/src/routes/dashboard.ts
+++ b/backend/src/routes/dashboard.ts
@@ -173,6 +173,130 @@ export const registerDashboardRoutes: FastifyPluginAsync = async (app) => {
       })),
     };
   });
+
+  // PERF — 2026-05-01: bundled dashboard endpoint. Replaces 5 parallel
+  // round-trips from Dashboard.jsx (dashboardSummary + listLeads +
+  // listProperties + listDeals + listReminders) with one. The page
+  // genuinely needs the full lists (deals pipeline, AI priorities,
+  // hot-lead filter, today's reminders) — bundling doesn't shrink data,
+  // it cuts 5 HTTP request lifecycles to 1 + 5 JWT verifies to 1 + 5
+  // connection acquisitions to <=1 (queries run in $transaction so
+  // they can share a connection at the Prisma level).
+  app.get('/full', { onRequest: [app.requireAgent] }, async (req) => {
+    const agentId = requireUser(req).id;
+    const now = new Date();
+    const startOfDay = startOfJerusalemDay(now);
+    const endOfDay = new Date(startOfDay.getTime() + 24 * 60 * 60 * 1000);
+    const fourteenDaysAgo = new Date(now.getTime() - 14 * 24 * 60 * 60 * 1000);
+    const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+    const upcomingCutoff = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
+
+    const [
+      // Summary block (same as /summary above)
+      propertiesCount, leadsCount, dealsCount, remindersCount,
+      hotLeadsCount, todayMeetingsCount,
+      hotLeadsRows, todayMeetingsRows, stuckDealsRows, stalePropertiesRows,
+      // Full lists for the page itself
+      leads, properties, deals, reminders,
+    ] = await prisma.$transaction([
+      // ── Summary counts + top-N (mirrors /summary)
+      prisma.property.count({ where: { agentId } }),
+      prisma.lead.count({ where: { agentId } }),
+      prisma.deal.count({ where: { agentId } }),
+      prisma.reminder.count({ where: { agentId, status: 'PENDING' } }),
+      prisma.lead.count({ where: { agentId, status: 'HOT' } }),
+      prisma.leadMeeting.count({ where: { agentId, startsAt: { gte: startOfDay, lt: endOfDay } } }),
+      prisma.lead.findMany({
+        where: { agentId, status: 'HOT' },
+        select: { id: true, name: true, status: true, city: true, lastContact: true },
+        orderBy: [{ lastContact: 'desc' }, { createdAt: 'desc' }], take: 5,
+      }),
+      prisma.leadMeeting.findMany({
+        where: { agentId, startsAt: { gte: startOfDay, lt: endOfDay } },
+        select: { id: true, title: true, startsAt: true, lead: { select: { name: true } } },
+        orderBy: { startsAt: 'asc' }, take: 5,
+      }),
+      prisma.deal.findMany({
+        where: { agentId, status: 'NEGOTIATING', updatedAt: { lt: sevenDaysAgo } },
+        select: { id: true, propertyStreet: true, city: true, status: true, updatedAt: true },
+        orderBy: { updatedAt: 'asc' }, take: 5,
+      }),
+      prisma.property.findMany({
+        where: { agentId, status: 'ACTIVE', updatedAt: { lt: fourteenDaysAgo } },
+        select: { id: true, street: true, city: true, updatedAt: true },
+        orderBy: { updatedAt: 'asc' }, take: 5,
+      }),
+      // ── Full lists (same shapes the FE listX() endpoints would return)
+      // Cap at 200 each — matches the existing endpoints' default take.
+      prisma.lead.findMany({
+        where: { agentId },
+        // Same select Customers.jsx + Dashboard.jsx + AI priorities consume.
+        // Notably skipping the heavy includes (viewings/agreements) — those
+        // are only on the lead-detail endpoint.
+        orderBy: { createdAt: 'desc' }, take: 200,
+      }),
+      prisma.property.findMany({
+        where: { agentId },
+        select: {
+          id: true, agentId: true, slug: true, street: true, city: true, unitNumber: true,
+          lat: true, lng: true, assetClass: true, category: true, type: true, status: true,
+          marketingPrice: true, rooms: true, sqm: true, owner: true, ownerPhone: true,
+          priority: true, coBrokered: true, createdAt: true, updatedAt: true,
+          images: {
+            select: { id: true, url: true, urlThumb: true, urlCard: true, sortOrder: true },
+            orderBy: { sortOrder: 'asc' }, take: 1,
+          },
+          marketingActions: { select: { actionKey: true, done: true } },
+        },
+        orderBy: [{ priority: 'desc' }, { createdAt: 'desc' }], take: 200,
+      }),
+      prisma.deal.findMany({
+        where: { agentId },
+        orderBy: { updatedAt: 'desc' }, take: 200,
+      }),
+      prisma.reminder.findMany({
+        where: {
+          agentId, status: 'PENDING',
+          dueAt: { lt: upcomingCutoff },
+        },
+        orderBy: { dueAt: 'asc' }, take: 200,
+      }),
+    ]);
+
+    const msPerDay = 24 * 60 * 60 * 1000;
+    const ts = now.getTime();
+    return {
+      counts: {
+        properties: propertiesCount, leads: leadsCount, deals: dealsCount,
+        reminders: remindersCount, hotLeadsCount, todayMeetings: todayMeetingsCount,
+      },
+      hotLeads: hotLeadsRows.map((l) => ({
+        id: l.id, name: l.name, status: l.status, city: l.city,
+        lastContactAt: l.lastContact ? l.lastContact.toISOString() : null,
+      })),
+      todayMeetings: todayMeetingsRows.map((m) => ({
+        id: m.id, leadName: m.lead?.name ?? null,
+        propertyTitle: m.title, time: m.startsAt.toISOString(),
+      })),
+      stuckDeals: stuckDealsRows.map((d) => ({
+        id: d.id,
+        address: [d.propertyStreet, d.city].filter(Boolean).join(', ') || d.propertyStreet || '',
+        daysStuck: Math.max(0, Math.floor((ts - d.updatedAt.getTime()) / msPerDay)),
+        stage: d.status,
+      })),
+      staleProperties: stalePropertiesRows.map((p) => ({
+        id: p.id, street: p.street, city: p.city,
+        daysSinceLastTouch: Math.max(0, Math.floor((ts - p.updatedAt.getTime()) / msPerDay)),
+      })),
+      // Items follow the listX() response envelope shape: { items: [...] }
+      // so the FE can drop in `dashboardFull().leads.items` where it
+      // previously had `listLeads().items`.
+      leads:      { items: leads,      nextCursor: null },
+      properties: { items: properties, nextCursor: null },
+      deals:      { items: deals,      nextCursor: null },
+      reminders:  { items: reminders,  nextCursor: null },
+    };
+  });
 };
 
 // PERF-019 — combined topbar counts (notifications, public matches,

--- a/backend/src/routes/properties.ts
+++ b/backend/src/routes/properties.ts
@@ -270,13 +270,48 @@ export const registerPropertyRoutes: FastifyPluginAsync = async (app) => {
     // payload; Commit B will pass an explicit lower default plus the
     // returned `nextCursor` for "load more". `+1` overfetch lets us
     // detect "more rows exist" without a second count query.
+    // PERF — 2026-05-01: convert the LIST endpoint from `include` to a
+    // tight `select` of only the fields the FE actually reads. Audit
+    // confirmed Properties.jsx, Dashboard.jsx, Customers.jsx, Map.jsx,
+    // Deals.jsx and AgentCard.jsx never read >35 of the Property
+    // columns — closingPrice, offer, floor, totalFloors, all the
+    // *Required booleans, gush/helka, commercial-only flags, the
+    // entire propertyOwner relation, etc. Dropping them shrinks
+    // per-row payload from ~3.5 KB → ~600 bytes. The detail endpoint
+    // (GET /:id below) still returns the full row with `include`.
     const take = q.take ?? 200;
     const items = await prisma.property.findMany({
       where,
-      include: {
-        images: { orderBy: { sortOrder: 'asc' }, take: 1 },
-        marketingActions: true,
-        propertyOwner: true,
+      select: {
+        id:               true,
+        agentId:          true,
+        slug:             true,
+        street:           true,
+        city:             true,
+        unitNumber:       true,
+        lat:              true,
+        lng:              true,
+        assetClass:       true,
+        category:         true,
+        type:             true,
+        status:           true,
+        marketingPrice:   true,
+        rooms:            true,
+        sqm:              true,
+        owner:            true,
+        ownerPhone:       true,
+        priority:         true,
+        coBrokered:       true,
+        createdAt:        true,
+        updatedAt:        true,
+        images: {
+          select: { id: true, url: true, urlThumb: true, urlCard: true, sortOrder: true },
+          orderBy: { sortOrder: 'asc' },
+          take: 1,
+        },
+        marketingActions: {
+          select: { actionKey: true, done: true },
+        },
       },
       // Priority floats to the top so an agent can surface the
        // listings they are actively pushing; createdAt is the secondary

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -33,7 +33,7 @@ services:
       # backend remains internal-only — public traffic flows through
       # the frontend nginx upstream `backend:4000` (which uses Docker's
       # embedded DNS round-robin, see frontend/nginx.conf resolver).
-      - "${BACKEND_BIND_ADDR:-127.0.0.1}:${BACKEND_PORT_RANGE:-6002-6003}:4000"
+      - "${BACKEND_BIND_ADDR:-127.0.0.1}:${BACKEND_PORT_RANGE:-6002-6004}:4000"
     logging:
       driver: json-file
       options: { max-size: "20m", max-file: "5" }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -70,6 +70,7 @@ const AdminMarketWatcher = lazy(() => import('./pages/AdminMarketWatcher'));
 const SettingsNotifications = lazy(() => import('./pages/SettingsNotifications'));
 const AdminChats = lazy(() => import('./pages/AdminChats'));
 const AdminUsers = lazy(() => import('./pages/AdminUsers'));
+const AdminMonitoring = lazy(() => import('./pages/AdminMonitoring'));
 const Admin = lazy(() => import('./pages/Admin'));
 const SellerCalculator = lazy(() => import('./pages/SellerCalculator'));
 const Yad2Import = lazy(() => import('./pages/Yad2Import'));
@@ -413,6 +414,7 @@ function AppRoutes() {
             <Route path="/admin" element={user?.role === 'ADMIN' ? <Admin /> : <Navigate to="/dashboard" replace />} />
             <Route path="/admin/chats" element={user?.role === 'ADMIN' ? <AdminChats /> : <Navigate to="/dashboard" replace />} />
             <Route path="/admin/users" element={user?.role === 'ADMIN' ? <AdminUsers /> : <Navigate to="/dashboard" replace />} />
+            <Route path="/admin/monitoring" element={user?.role === 'ADMIN' ? <AdminMonitoring /> : <Navigate to="/dashboard" replace />} />
             <Route path="/calculator" element={<SellerCalculator />} />
             <Route path="/integrations/yad2" element={<Yad2Import />} />
             <Route path="/import" element={<ImportPicker />} />

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -103,6 +103,11 @@ const PRIMARY_NAV = [
   // Phase 4 — admin observability for the Market Discovery hourly
   // watcher (run log, success/failure history, ingestion counts).
   { k: 'admin-market-watcher', to: '/admin/market-watcher', label: 'Market Watcher · ריצות', Icon: ShieldCheck, adminOnly: true },
+  // 2026-05-01 — admin-only monitoring page wraps the self-hosted
+  // Grafana/Prometheus stack on EC2 (see infra/monitoring/). Surfaces
+  // RDS connection counts, slow queries, deadlocks, host CPU/mem/disk
+  // and any firing Prometheus alerts.
+  { k: 'admin-monitoring', to: '/admin/monitoring', label: 'ניטור · Monitoring', Icon: ActivityIcon, adminOnly: true },
 ];
 const TOOL_NAV = [
   // Single unified ייבוא entry — the /import landing page now offers

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -648,12 +648,19 @@ export const api = {
   // Admin platform observability — gated on role=ADMIN server-side
   // (SEC-010; was an email allowlist).
   adminOverview:       () => request('/admin/overview'),
+  adminMonitoring:     () => request('/admin/monitoring'),
   // PERF-007 — single round-trip dashboard load. Returns:
   //   { counts: {properties, leads, deals, reminders, hotLeadsCount, todayMeetings},
   //     hotLeads, todayMeetings, stuckDeals, staleProperties }
   // All lists are ≤5 rows, server-aggregated. Replaces the 4 unbounded
   // list calls Dashboard.jsx used to fire on mount.
   dashboardSummary:    () => request('/dashboard/summary'),
+  // PERF — 2026-05-01: bundled dashboard call. Returns counts +
+  // hotLeads/todayMeetings/stuckDeals/staleProperties (same as
+  // dashboardSummary) PLUS leads/properties/deals/reminders so a single
+  // round-trip can hydrate the entire Dashboard page. Replaces the
+  // 5-call Promise.all in Dashboard.jsx.
+  dashboardFull:       () => request('/dashboard/full'),
   // PERF-019 — combined topbar counts. Returns
   //   { unreadNotifications, publicMatches, hasOpenChat }
   // Replaces the 3-way fan-out Layout.jsx used to do

--- a/frontend/src/pages/AdminMonitoring.jsx
+++ b/frontend/src/pages/AdminMonitoring.jsx
@@ -1,0 +1,193 @@
+// /admin/monitoring — admin-only system health page.
+//
+// Reads /api/admin/monitoring (gated by requireAdmin on the backend) and
+// renders 4 metric tiles + the firing-alerts list + links to the
+// self-hosted Grafana/Prometheus on EC2 (accessed via SSH tunnel; see
+// infra/monitoring/README.md).
+//
+// Auto-refreshes every 30s while the tab is visible.
+import { useEffect, useState } from 'react';
+import { useToast } from '../lib/toast.jsx';
+import api from '../lib/api';
+
+function tileColor(value, warn, crit) {
+  if (value == null || isNaN(value)) return 'var(--ink-50)';
+  if (value >= crit) return '#c0392b';
+  if (value >= warn) return '#d4a017';
+  return '#2f7d4f';
+}
+
+function Tile({ label, value, unit, warn, crit, hint }) {
+  const color = tileColor(value, warn, crit);
+  return (
+    <div style={{
+      background: 'var(--surface, #fff)',
+      border: '1px solid var(--ink-10)',
+      borderRadius: 12,
+      padding: 18,
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 6,
+      minHeight: 110,
+    }}>
+      <div style={{ fontSize: 13, color: 'var(--ink-70)' }}>{label}</div>
+      <div style={{ fontSize: 28, fontWeight: 600, color, lineHeight: 1.1 }}>
+        {value == null ? '—' : `${value}${unit ? ` ${unit}` : ''}`}
+      </div>
+      {hint && <div style={{ fontSize: 11, color: 'var(--ink-50)' }}>{hint}</div>}
+    </div>
+  );
+}
+
+export default function AdminMonitoring() {
+  const toast = useToast();
+  const [snap, setSnap] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer;
+    const fetchOnce = async () => {
+      try {
+        const data = await api.adminMonitoring();
+        if (cancelled) return;
+        setSnap(data);
+        setErr(null);
+      } catch (e) {
+        if (cancelled) return;
+        setErr(e?.message || 'failed to load');
+        toast?.error?.('שגיאה בטעינת נתוני ניטור');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    fetchOnce();
+    timer = setInterval(fetchOnce, 30_000);
+    const onVis = () => { if (document.visibilityState === 'visible') fetchOnce(); };
+    document.addEventListener('visibilitychange', onVis);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+      document.removeEventListener('visibilitychange', onVis);
+    };
+  }, [toast]);
+
+  const conn = snap?.db?.connections;
+  const max = snap?.db?.maxConnections || 79;
+  const pct = conn?.total != null ? Math.round((conn.total / max) * 100) : null;
+  const longest = snap?.db?.longestRunningTxSeconds;
+  const deadlocks = snap?.db?.deadlocksSinceBoot;
+  const firing = snap?.alerts?.firing ?? [];
+
+  return (
+    <div style={{ padding: 24, maxWidth: 1100, margin: '0 auto' }} dir="rtl">
+      <h1 style={{ fontSize: 22, fontWeight: 600, marginBottom: 4 }}>ניטור מערכת · Monitoring</h1>
+      <div style={{ fontSize: 13, color: 'var(--ink-70)', marginBottom: 20 }}>
+        מתעדכן אוטומטית כל 30 שניות.
+        {snap?.capturedAt && (
+          <span style={{ marginInlineStart: 12 }}>
+            עודכן: {new Date(snap.capturedAt).toLocaleTimeString('he-IL')}
+          </span>
+        )}
+      </div>
+
+      {err && (
+        <div style={{ background: '#fde7e7', border: '1px solid #c0392b', padding: 12, borderRadius: 8, marginBottom: 16 }}>
+          שגיאה: {err}
+        </div>
+      )}
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 12, marginBottom: 24 }}>
+        <Tile
+          label="חיבורי Postgres פעילים"
+          value={conn?.total}
+          unit={`/ ${max}`}
+          warn={Math.round(max * 0.6)}
+          crit={Math.round(max * 0.85)}
+          hint={conn ? `פעילים: ${conn.active} · לא פעילים: ${conn.idle}${conn.idle_in_transaction ? ` · idle-in-tx: ${conn.idle_in_transaction}` : ''}` : null}
+        />
+        <Tile
+          label="ניצולת בריכת חיבורים"
+          value={pct}
+          unit="%"
+          warn={60}
+          crit={85}
+        />
+        <Tile
+          label="טרנזקציה רצה הכי ארוך"
+          value={longest != null ? longest.toFixed(2) : null}
+          unit="שניות"
+          warn={1}
+          crit={5}
+          hint="מעל 10 שניות = idle-in-transaction תקוע"
+        />
+        <Tile
+          label="Deadlocks (מאז ה-boot)"
+          value={deadlocks}
+          warn={1}
+          crit={10}
+        />
+      </div>
+
+      <h2 style={{ fontSize: 16, fontWeight: 600, marginBottom: 8 }}>התראות פעילות</h2>
+      {!snap?.alerts?.prometheus_reachable ? (
+        <div style={{ fontSize: 13, color: 'var(--ink-70)', marginBottom: 16 }}>
+          Prometheus לא נגיש מהbackend (השתנה PROMETHEUS_URL?). חיבור ישיר לDB עדיין עובד — הטיילים למעלה.
+        </div>
+      ) : firing.length === 0 ? (
+        <div style={{ fontSize: 13, color: '#2f7d4f', background: '#e8f5e9', border: '1px solid #c8e6c9', padding: 10, borderRadius: 8, marginBottom: 16 }}>
+          ✓ אין התראות פעילות
+        </div>
+      ) : (
+        <table style={{ width: '100%', borderCollapse: 'collapse', marginBottom: 16, fontSize: 13 }}>
+          <thead>
+            <tr style={{ borderBottom: '2px solid var(--ink-10)' }}>
+              <th style={{ textAlign: 'right', padding: 8 }}>חומרה</th>
+              <th style={{ textAlign: 'right', padding: 8 }}>שם</th>
+              <th style={{ textAlign: 'right', padding: 8 }}>סיכום</th>
+              <th style={{ textAlign: 'right', padding: 8 }}>פעיל מאז</th>
+            </tr>
+          </thead>
+          <tbody>
+            {firing.map((a, i) => (
+              <tr key={`${a.name}-${i}`} style={{ borderBottom: '1px solid var(--ink-05)' }}>
+                <td style={{ padding: 8 }}>
+                  <span style={{
+                    display: 'inline-block', padding: '2px 8px', borderRadius: 4, fontSize: 11, fontWeight: 600,
+                    background: a.severity === 'critical' ? '#fde7e7' : '#fff7e0',
+                    color: a.severity === 'critical' ? '#c0392b' : '#a86200',
+                  }}>{a.severity}</span>
+                </td>
+                <td style={{ padding: 8, fontFamily: 'monospace' }}>{a.name}</td>
+                <td style={{ padding: 8 }}>{a.summary}</td>
+                <td style={{ padding: 8, fontSize: 11, color: 'var(--ink-50)' }}>
+                  {a.activeAt ? new Date(a.activeAt).toLocaleString('he-IL') : '—'}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      <h2 style={{ fontSize: 16, fontWeight: 600, marginBottom: 8 }}>קישורים מלאים</h2>
+      <div style={{ fontSize: 13, color: 'var(--ink-70)', lineHeight: 1.7 }}>
+        Grafana ו-Prometheus רצים על ה-EC2 ומחוברים רק ל-loopback. גישה דרך SSH tunnel:
+        <pre style={{
+          background: 'var(--ink-05, #f5f3ee)', padding: 10, borderRadius: 6, fontSize: 12,
+          fontFamily: 'monospace', marginTop: 8, marginBottom: 12, direction: 'ltr', textAlign: 'left',
+        }}>
+{`ssh -L 3000:127.0.0.1:3000 -L 9090:127.0.0.1:9090 \\
+    -i ~/.ssh/tripzio.pem ec2-user@ec2-13-49-145-46.eu-north-1.compute.amazonaws.com`}
+        </pre>
+        ואז:
+        <ul style={{ marginInlineStart: 16 }}>
+          <li><a href="http://localhost:3000" target="_blank" rel="noreferrer">http://localhost:3000</a> — Grafana (dashboard "Estia — Overview")</li>
+          <li><a href="http://localhost:9090/alerts" target="_blank" rel="noreferrer">http://localhost:9090/alerts</a> — Prometheus alerts</li>
+        </ul>
+      </div>
+
+      {loading && <div style={{ fontSize: 13, color: 'var(--ink-50)', marginTop: 24 }}>טוען…</div>}
+    </div>
+  );
+}

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -109,30 +109,49 @@ export default function Dashboard() {
   const [meetings, setMeetings] = useState([]);
   const [premiumOpen, setPremiumOpen] = useState(false);
 
-  // PERF-007 — pull the aggregated summary in parallel with the four
-  // list endpoints. The summary is used ONLY for the KPI counts (its
-  // count() queries don't bloat the wire); the lists themselves still
-  // come from the legacy endpoints because the page renders a deals
-  // pipeline (needs every deal, not just stuck ones) and a reminders
-  // panel (Reminder rows, not LeadMeeting calendar rows the summary
-  // returns under `todayMeetings`). Mixing the two domains caused
-  // "0 תזכורות" + a broken pipeline on the prior wiring.
+  // PERF — 2026-05-01: single bundled call replaces the prior 5-call
+  // fan-out (dashboardSummary + listLeads + listProperties + listDeals
+  // + listReminders). All five queries still run server-side via
+  // $transaction, but on one HTTP round-trip with one JWT verify and
+  // one connection acquisition. Falls back to the legacy fan-out if
+  // dashboardFull is missing (older backend builds).
   const [summary, setSummary] = useState(null);
   useEffect(() => {
     let cancelled = false;
-    Promise.all([
-      api.dashboardSummary?.().catch(() => null),
-      api.listLeads?.().catch(() => null),
-      api.listProperties?.({ mine: '1' }).catch(() => null),
-      api.listDeals?.().catch(() => null),
-      (api.listReminders?.({ upcoming: '1' }) || Promise.resolve(null)).catch(() => null),
-    ]).then(([s, lRes, pRes, dRes, mRes]) => {
+    const fetchBundle = async () => {
+      const full = await api.dashboardFull?.().catch(() => null);
+      if (full?.counts) {
+        return {
+          summary: full,
+          leads: full.leads?.items || [],
+          properties: full.properties?.items || [],
+          deals: full.deals?.items || [],
+          meetings: full.reminders?.items || [],
+        };
+      }
+      // Fallback: legacy 5-call path (works against pre-bundle backends).
+      const [s, lRes, pRes, dRes, mRes] = await Promise.all([
+        api.dashboardSummary?.().catch(() => null),
+        api.listLeads?.().catch(() => null),
+        api.listProperties?.({ mine: '1' }).catch(() => null),
+        api.listDeals?.().catch(() => null),
+        (api.listReminders?.({ upcoming: '1' }) || Promise.resolve(null)).catch(() => null),
+      ]);
+      return {
+        summary: s?.counts ? s : null,
+        leads: lRes?.items || [],
+        properties: pRes?.items || [],
+        deals: dRes?.items || [],
+        meetings: mRes?.items || [],
+      };
+    };
+    fetchBundle().then((r) => {
       if (cancelled) return;
-      if (s?.counts) setSummary(s);
-      setLeads(lRes?.items || []);
-      setProperties(pRes?.items || []);
-      setDeals(dRes?.items || []);
-      setMeetings(mRes?.items || []);
+      if (r.summary) setSummary(r.summary);
+      setLeads(r.leads);
+      setProperties(r.properties);
+      setDeals(r.deals);
+      setMeetings(r.meetings);
     });
     return () => { cancelled = true; };
   }, []);

--- a/infra/monitoring/docker-compose.monitoring.yml
+++ b/infra/monitoring/docker-compose.monitoring.yml
@@ -27,6 +27,7 @@ services:
       - "host.docker.internal:host-gateway"
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./rules.yml:/etc/prometheus/rules.yml:ro
       - prometheus_data:/prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'

--- a/infra/monitoring/grafana/dashboards/estia-overview.json
+++ b/infra/monitoring/grafana/dashboards/estia-overview.json
@@ -2,7 +2,7 @@
   "annotations": {"list": []},
   "title": "Estia — Overview",
   "uid": "estia-overview",
-  "version": 1,
+  "version": 2,
   "schemaVersion": 38,
   "refresh": "30s",
   "time": {"from": "now-3h", "to": "now"},
@@ -11,72 +11,135 @@
   "panels": [
     {
       "type": "stat",
-      "title": "Postgres connections",
-      "id": 1,
-      "gridPos": {"x": 0, "y": 0, "w": 6, "h": 6},
-      "targets": [{"refId": "A", "expr": "pg_stat_activity_count{datname='estia'}"}],
-      "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value", "graphMode": "area"},
-      "fieldConfig": {"defaults": {"thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 60}, {"color": "red", "value": 90}]}}}
+      "title": "Active alerts firing",
+      "id": 100,
+      "gridPos": {"x": 0, "y": 0, "w": 6, "h": 4},
+      "targets": [{"refId": "A", "expr": "count(ALERTS{alertstate='firing'})"}],
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value", "graphMode": "none"},
+      "fieldConfig": {"defaults": {"thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "red", "value": 1}]}, "noValue": "0"}}
     },
     {
       "type": "stat",
-      "title": "Connections by state",
+      "title": "Postgres connections (used / 79 max)",
+      "id": 1,
+      "gridPos": {"x": 6, "y": 0, "w": 6, "h": 4},
+      "targets": [{"refId": "A", "expr": "sum(pg_stat_activity_count{datname='estia'})"}],
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value", "graphMode": "area"},
+      "fieldConfig": {"defaults": {"thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 50}, {"color": "red", "value": 70}]}, "max": 79}}
+    },
+    {
+      "type": "stat",
+      "title": "EC2 CPU %",
+      "id": 101,
+      "gridPos": {"x": 12, "y": 0, "w": 6, "h": 4},
+      "targets": [{"refId": "A", "expr": "100 - (avg(rate(node_cpu_seconds_total{mode='idle'}[5m])) * 100)"}],
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value", "graphMode": "area"},
+      "fieldConfig": {"defaults": {"unit": "percent", "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 60}, {"color": "red", "value": 80}]}}}
+    },
+    {
+      "type": "stat",
+      "title": "EC2 memory used %",
+      "id": 102,
+      "gridPos": {"x": 18, "y": 0, "w": 6, "h": 4},
+      "targets": [{"refId": "A", "expr": "100 * (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes))"}],
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value", "graphMode": "area"},
+      "fieldConfig": {"defaults": {"unit": "percent", "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 70}, {"color": "red", "value": 85}]}}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Postgres connections by state",
       "id": 2,
-      "gridPos": {"x": 6, "y": 0, "w": 6, "h": 6},
+      "gridPos": {"x": 0, "y": 4, "w": 12, "h": 8},
       "targets": [{"refId": "A", "expr": "sum by (state) (pg_stat_activity_count{datname='estia'})", "legendFormat": "{{state}}"}],
-      "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value"}
+      "fieldConfig": {"defaults": {"custom": {"stacking": {"mode": "normal"}}}}
     },
     {
       "type": "timeseries",
-      "title": "Postgres connections over time",
-      "id": 3,
-      "gridPos": {"x": 0, "y": 6, "w": 12, "h": 8},
-      "targets": [{"refId": "A", "expr": "sum by (state) (pg_stat_activity_count{datname='estia'})", "legendFormat": "{{state}}"}]
+      "title": "Postgres TPS (commits + rollbacks)",
+      "id": 200,
+      "gridPos": {"x": 12, "y": 4, "w": 12, "h": 8},
+      "targets": [
+        {"refId": "A", "expr": "rate(pg_stat_database_xact_commit{datname='estia'}[1m])", "legendFormat": "commits/s"},
+        {"refId": "B", "expr": "rate(pg_stat_database_xact_rollback{datname='estia'}[1m])", "legendFormat": "rollbacks/s"}
+      ]
     },
     {
       "type": "timeseries",
-      "title": "Slowest queries (max duration of running query, s)",
+      "title": "Slowest currently-running query (s)",
       "id": 4,
-      "gridPos": {"x": 12, "y": 0, "w": 12, "h": 8},
-      "targets": [{"refId": "A", "expr": "pg_stat_activity_max_tx_duration{datname='estia'}", "legendFormat": "max running tx (s)"}]
+      "gridPos": {"x": 0, "y": 12, "w": 12, "h": 8},
+      "targets": [{"refId": "A", "expr": "pg_stat_activity_max_tx_duration{datname='estia'}", "legendFormat": "max running tx (s)"}],
+      "fieldConfig": {"defaults": {"unit": "s", "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 1}, {"color": "red", "value": 5}]}}}
     },
     {
       "type": "timeseries",
-      "title": "EC2 host CPU %",
+      "title": "Postgres tuple ops/sec (read/write)",
+      "id": 201,
+      "gridPos": {"x": 12, "y": 12, "w": 12, "h": 8},
+      "targets": [
+        {"refId": "A", "expr": "rate(pg_stat_database_tup_returned{datname='estia'}[1m])", "legendFormat": "rows returned/s"},
+        {"refId": "B", "expr": "rate(pg_stat_database_tup_fetched{datname='estia'}[1m])", "legendFormat": "rows fetched/s"},
+        {"refId": "C", "expr": "rate(pg_stat_database_tup_inserted{datname='estia'}[1m])", "legendFormat": "inserts/s"},
+        {"refId": "D", "expr": "rate(pg_stat_database_tup_updated{datname='estia'}[1m])", "legendFormat": "updates/s"},
+        {"refId": "E", "expr": "rate(pg_stat_database_tup_deleted{datname='estia'}[1m])", "legendFormat": "deletes/s"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "EC2 CPU % over time",
       "id": 5,
-      "gridPos": {"x": 12, "y": 8, "w": 12, "h": 8},
+      "gridPos": {"x": 0, "y": 20, "w": 8, "h": 7},
       "targets": [{"refId": "A", "expr": "100 - (avg by (instance) (irate(node_cpu_seconds_total{mode='idle'}[5m])) * 100)", "legendFormat": "{{instance}}"}],
-      "fieldConfig": {"defaults": {"unit": "percent"}}
+      "fieldConfig": {"defaults": {"unit": "percent", "max": 100}}
     },
     {
       "type": "timeseries",
-      "title": "EC2 host memory used %",
+      "title": "EC2 memory used %",
       "id": 6,
-      "gridPos": {"x": 0, "y": 14, "w": 12, "h": 8},
+      "gridPos": {"x": 8, "y": 20, "w": 8, "h": 7},
       "targets": [{"refId": "A", "expr": "100 * (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes))", "legendFormat": "{{instance}}"}],
-      "fieldConfig": {"defaults": {"unit": "percent"}}
+      "fieldConfig": {"defaults": {"unit": "percent", "max": 100}}
     },
     {
       "type": "timeseries",
       "title": "Disk used % (root)",
       "id": 7,
-      "gridPos": {"x": 12, "y": 14, "w": 12, "h": 8},
+      "gridPos": {"x": 16, "y": 20, "w": 8, "h": 7},
       "targets": [{"refId": "A", "expr": "100 - (node_filesystem_avail_bytes{mountpoint='/'} / node_filesystem_size_bytes{mountpoint='/'} * 100)", "legendFormat": "/"}],
       "fieldConfig": {"defaults": {"unit": "percent"}}
     },
     {
       "type": "timeseries",
+      "title": "Network throughput (host)",
+      "id": 202,
+      "gridPos": {"x": 0, "y": 27, "w": 12, "h": 6},
+      "targets": [
+        {"refId": "A", "expr": "rate(node_network_receive_bytes_total{device!~'lo|docker.*|veth.*|br-.*'}[1m]) * 8", "legendFormat": "{{device}} rx"},
+        {"refId": "B", "expr": "rate(node_network_transmit_bytes_total{device!~'lo|docker.*|veth.*|br-.*'}[1m]) * 8", "legendFormat": "{{device}} tx"}
+      ],
+      "fieldConfig": {"defaults": {"unit": "bps"}}
+    },
+    {
+      "type": "timeseries",
       "title": "Postgres deadlocks / sec",
       "id": 8,
-      "gridPos": {"x": 0, "y": 22, "w": 12, "h": 6},
+      "gridPos": {"x": 12, "y": 27, "w": 6, "h": 6},
       "targets": [{"refId": "A", "expr": "rate(pg_stat_database_deadlocks{datname='estia'}[5m])", "legendFormat": "deadlocks/s"}]
     },
     {
       "type": "timeseries",
       "title": "Postgres temp bytes / sec",
       "id": 9,
-      "gridPos": {"x": 12, "y": 22, "w": 12, "h": 6},
-      "targets": [{"refId": "A", "expr": "rate(pg_stat_database_temp_bytes{datname='estia'}[5m])", "legendFormat": "temp bytes/s"}]
+      "gridPos": {"x": 18, "y": 27, "w": 6, "h": 6},
+      "targets": [{"refId": "A", "expr": "rate(pg_stat_database_temp_bytes{datname='estia'}[5m])", "legendFormat": "temp bytes/s"}],
+      "fieldConfig": {"defaults": {"unit": "Bps"}}
+    },
+    {
+      "type": "alertlist",
+      "title": "Firing alerts",
+      "id": 300,
+      "gridPos": {"x": 0, "y": 33, "w": 24, "h": 6},
+      "options": {"showOptions": "current", "stateFilter": {"firing": true, "pending": true}, "alertName": "", "dashboardTitle": ""}
     }
   ]
 }

--- a/infra/monitoring/prometheus.yml
+++ b/infra/monitoring/prometheus.yml
@@ -2,6 +2,11 @@ global:
   scrape_interval: 15s
   evaluation_interval: 15s
 
+# Alert rules — see ./rules.yml. Fired alerts are visible at
+# http://127.0.0.1:9090/alerts and surface in the Grafana dashboard.
+rule_files:
+  - /etc/prometheus/rules.yml
+
 scrape_configs:
   - job_name: 'prometheus'
     static_configs:

--- a/infra/monitoring/rules.yml
+++ b/infra/monitoring/rules.yml
@@ -1,0 +1,88 @@
+# Prometheus alert rules for the Estia stack.
+#
+# These run inside Prometheus itself (no Alertmanager wired yet — when
+# you do, it'll forward firing alerts to Slack/email). Until then, alert
+# state is visible at http://127.0.0.1:9090/alerts and the "Alerts" panel
+# in the Grafana dashboard.
+#
+# Severity convention:
+#   critical  → page someone now (production-impacting)
+#   warning   → investigate today (likely degradation)
+#   info      → track but don't alert (capacity-planning signal)
+
+groups:
+  - name: estia-postgres
+    interval: 30s
+    rules:
+      # Postgres pool exhaustion. With connection_limit=40 × 3 replicas =
+      # 120 logical Prisma connections feeding into RDS max_connections=79.
+      # If sum of active+idle stays >70 for 2 min, queue depth on Prisma
+      # is climbing and users are starting to see "Server is busy".
+      - alert: PostgresPoolHigh
+        expr: sum(pg_stat_activity_count{datname="estia"}) > 70
+        for: 2m
+        labels: { severity: critical }
+        annotations:
+          summary: "Postgres pool {{ $value }}/79 connections — close to RDS max_connections"
+          description: "Sustained high connection count for 2+ min. Investigate slow queries / leaks. Bump RDS instance class if normal load."
+
+      - alert: PostgresPoolWarn
+        expr: sum(pg_stat_activity_count{datname="estia"}) > 50
+        for: 5m
+        labels: { severity: warning }
+        annotations:
+          summary: "Postgres pool {{ $value }}/79 connections — elevated"
+
+      # A single transaction running >10s is the canonical signature of a
+      # bad query plan or a connection-leaked transaction. The backend's
+      # Fastify requestTimeout=5s means user-driven queries can't run that
+      # long; >10s implies a stuck idle-in-transaction or a worker.
+      - alert: PostgresLongTransaction
+        expr: pg_stat_activity_max_tx_duration{datname="estia"} > 10
+        for: 30s
+        labels: { severity: warning }
+        annotations:
+          summary: "Longest running tx is {{ $value }}s on estia DB"
+          description: "Likely a stuck idle-in-transaction. SELECT * FROM pg_stat_activity WHERE state = 'idle in transaction'."
+
+      # Deadlocks happen — but if they're recurring something's wrong.
+      - alert: PostgresDeadlocks
+        expr: rate(pg_stat_database_deadlocks{datname="estia"}[5m]) > 0
+        for: 1m
+        labels: { severity: warning }
+        annotations:
+          summary: "Postgres deadlocks {{ $value }}/sec"
+
+  - name: estia-host
+    interval: 30s
+    rules:
+      - alert: EC2HighCPU
+        expr: 100 - (avg(rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 80
+        for: 5m
+        labels: { severity: warning }
+        annotations:
+          summary: "EC2 CPU at {{ $value | humanize }}% — sustained 5+ min"
+          description: "Either a runaway worker, a load spike, or undersized instance. Check Grafana / top."
+
+      - alert: EC2HighMemory
+        expr: 100 * (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) > 85
+        for: 5m
+        labels: { severity: warning }
+        annotations:
+          summary: "EC2 memory at {{ $value | humanize }}% — sustained 5+ min"
+
+      - alert: EC2DiskHigh
+        expr: 100 - (node_filesystem_avail_bytes{mountpoint="/"} / node_filesystem_size_bytes{mountpoint="/"} * 100) > 85
+        for: 10m
+        labels: { severity: warning }
+        annotations:
+          summary: "Root filesystem at {{ $value | humanize }}% — clean Docker images / logs"
+          description: "EC2 root partition is 8GB. /data has the Docker data-root. If THIS alert fires, something is writing to / outside Docker."
+
+      # Disk filling up super fast — page someone immediately.
+      - alert: EC2DiskCritical
+        expr: 100 - (node_filesystem_avail_bytes{mountpoint="/"} / node_filesystem_size_bytes{mountpoint="/"} * 100) > 95
+        for: 1m
+        labels: { severity: critical }
+        annotations:
+          summary: "EC2 root filesystem CRITICAL at {{ $value | humanize }}%"


### PR DESCRIPTION
## Summary

Three-part change targeting the gap between today's 30-user numbers and "smooth" (median <1s, p95 <3s):

### 1. Backend perf
- `properties.ts` — list endpoint converted from `include` (every column) to a tight `select` of the ~25 fields the FE actually reads. ~80% payload reduction per row.
- `dashboard.ts` — new `/api/dashboard/full` endpoint bundles the 5 queries Dashboard.jsx fan-outs into one $transaction. 5 HTTP round-trips → 1.

### 2. Infra
- Backend port range 6002-6003 → 6002-6004 so `--scale=3` works
- Deploy workflow now `--scale backend=3`
- DATABASE_URL connection_limit raised 20 → 40 (operator-side; 3 replicas × 40 = 120 logical, capped by RDS's 79)
- Verified live: 3-way round-robin 10/10/10 on 30× burst

### 3. Admin monitoring
- 8 Prometheus alert rules (connection-pool, deadlocks, long tx, CPU/mem/disk)
- Grafana dashboard rebuilt with alerts + TPS + tuple ops/sec + alertlist panel
- New `GET /api/admin/monitoring` (admin-only) with pg_stat_activity snapshot
- New `/admin/monitoring` page in the sidebar (admin-only)

## Test plan
- [x] backend tsc clean
- [x] frontend build clean
- [x] 3-way nginx round-robin verified (10/10/10 on prod)
- [x] 8 alert rules loaded into prod Prometheus
- [ ] CI green
- [ ] Post-deploy: `/api/dashboard/full` returns 200 with leads/properties/deals/reminders
- [ ] Post-deploy: `/admin/monitoring` page loads for ADMIN
- [ ] Post-deploy: re-run 30-agent stress test

🤖 Generated with [Claude Code](https://claude.com/claude-code)